### PR TITLE
fix: cors_origins str type for Cloud Run

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,3 @@
-from pydantic import field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -10,21 +9,13 @@ class Settings(BaseSettings):
 
     nominatim_url: str = "https://nominatim.openstreetmap.org"
     overpass_url: str = "https://overpass-api.de/api/interpreter"
-    cors_origins: list[str] = ["http://localhost:5173", "http://localhost:3000"]
+    cors_origins: str = "http://localhost:5173,http://localhost:3000"
     cache_db_path: str = "./cache.db"
     log_level: str = "INFO"
 
-    @field_validator("cors_origins", mode="before")
-    @classmethod
-    def parse_cors_origins(cls, v: object) -> object:
-        if isinstance(v, str):
-            import json
-
-            try:
-                return json.loads(v)
-            except json.JSONDecodeError:
-                return [s.strip() for s in v.split(",") if s.strip()]
-        return v
+    @property
+    def cors_origins_list(self) -> list[str]:
+        return [s.strip() for s in self.cors_origins.split(",") if s.strip()]
 
     model_config = {"env_file": ".env"}
 

--- a/app/main.py
+++ b/app/main.py
@@ -40,7 +40,7 @@ app.add_exception_handler(DescriptorError, descriptor_error_handler)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=settings.cors_origins,
+    allow_origins=settings.cors_origins_list,
     allow_credentials=True,
     allow_methods=["GET", "POST"],
     allow_headers=["*"],


### PR DESCRIPTION
Use plain str + property split instead of list[str] to avoid pydantic-settings JSON parsing