### PR TITLE
fix: update Gemini model from 2.0-flash to 2.5-flash

### DIFF
--- a/app/modules/describer.py
+++ b/app/modules/describer.py
@@ -58,7 +58,7 @@ async def describe_image(
 
     client = genai.Client(api_key=settings.google_ai_api_key)
     response = client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents=[
             genai.types.Part.from_bytes(data=image_bytes, mime_type="image/png"),
             prompt,


### PR DESCRIPTION
## Summary
- `gemini-2.0-flash` 모델이 더 이상 사용 불가(404)하여 `gemini-2.5-flash`로 업데이트

## Test plan
- [ ] 배포 후 `/api/describe` 엔드포인트에서 description이 정상 생성되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)