### PR TITLE
fix: add GitHub Pages origin to CORS_ORIGINS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
           region: asia-northeast1
           source: .
           env_vars: |
-            CORS_ORIGINS=https://cognito.conaonda.com,http://localhost:5173
+            CORS_ORIGINS=https://cognito.conaonda.com,https://conaonda.github.io,http://localhost:5173
             LOG_LEVEL=INFO
             CACHE_DB_PATH=/tmp/cache/cache.db
           secrets: |


### PR DESCRIPTION
## Summary
- Add `https://conaonda.github.io` to `CORS_ORIGINS` in deploy workflow
- Fixes CORS preflight failure when calling `/api/describe` from GitHub Pages

## Test plan
- [ ] PR 머지 후 Cloud Run 자동 배포 확인
- [ ] `https://conaonda.github.io`에서 `/api/describe` 호출 시 CORS 에러 해소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)