### PR TITLE
fix: use space delimiter for CORS_ORIGINS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
           region: asia-northeast1
           source: .
           env_vars: |
-            CORS_ORIGINS=https://cognito.conaonda.com,https://conaonda.github.io,http://localhost:5173
+            CORS_ORIGINS=https://cognito.conaonda.com https://conaonda.github.io http://localhost:5173
             LOG_LEVEL=INFO
             CACHE_DB_PATH=/tmp/cache/cache.db
           secrets: |

--- a/app/config.py
+++ b/app/config.py
@@ -9,14 +9,14 @@ class Settings(BaseSettings):
 
     nominatim_url: str = "https://nominatim.openstreetmap.org"
     overpass_url: str = "https://overpass-api.de/api/interpreter"
-    cors_origins: str = "http://localhost:5173,http://localhost:3000"
+    cors_origins: str = "http://localhost:5173 http://localhost:3000"
     cache_db_path: str = "./cache.db"
     log_level: str = "INFO"
     thumbnail_max_pixels: int = 768
 
     @property
     def cors_origins_list(self) -> list[str]:
-        return [s.strip() for s in self.cors_origins.split(",") if s.strip()]
+        return [s.strip() for s in self.cors_origins.split() if s.strip()]
 
     model_config = {"env_file": ".env"}
 


### PR DESCRIPTION
## Summary
- gcloud `--update-env-vars` uses `^,^` as separator, breaking comma-delimited `CORS_ORIGINS` values
- Switch to space-delimited format in both `deploy.yml` and `config.py`
- Fixes `https://conaonda.github.io` CORS preflight failure

## Test plan
- [ ] 배포 후 `curl -X OPTIONS -H "Origin: https://conaonda.github.io"` preflight 200 확인
- [ ] 기존 `https://cognito.conaonda.com` CORS 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)