### PR TITLE
fix: make captured_at optional (v0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.1] - 2026-02-28
+
+### Changed
+
+- `captured_at` 필드를 optional로 변경 (촬영일자 없이도 설명 생성 가능)
+
+## [0.3.0] - 2026-02-20
+
+### Added
+
+- API key 인증 및 Rate limiting
+- Supabase 연동 (결과 저장)
+- CORS 설정
+
+## [0.2.0] - 2026-02-15
+
+### Added
+
+- Context 모듈 (DuckDuckGo 검색)
+- LandCover 모듈 (Overpass API)
+- Geocoder 모듈 (Nominatim)
+
+## [0.1.0] - 2026-02-10
+
+### Added
+
+- Describer 모듈 (Gemini 2.0 Flash)
+- 기본 FastAPI 구조

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -9,7 +9,7 @@ class DescribeRequest(BaseModel):
     bbox: list[float] | None = Field(
         None, description="[west, south, east, north]", min_length=4, max_length=4
     )
-    captured_at: str = Field(description="Capture date in ISO 8601 format")
+    captured_at: str | None = Field(None, description="Capture date in ISO 8601 format")
     cog_image_id: str | None = Field(None, description="Optional cog_images UUID for DB linking")
 
 

--- a/app/modules/context.py
+++ b/app/modules/context.py
@@ -13,7 +13,7 @@ async def research_context(
     cache: CacheStore,
 ) -> Context:
     # 캐시 키: 지역명 + 월 단위
-    month = captured_at[:7] if len(captured_at) >= 7 else captured_at
+    month = captured_at[:7] if captured_at and len(captured_at) >= 7 else (captured_at or "unknown")
     cache_key = f"context:{place_name}:{month}"
 
     cached = await cache.get(cache_key)

--- a/app/modules/describer.py
+++ b/app/modules/describer.py
@@ -46,7 +46,7 @@ def _resize_for_gemini(image_bytes: bytes, max_size: int) -> bytes:
 def _make_prompt(place_name: str, captured_at: str, land_cover_summary: str) -> str:
     return f"""이 위성영상을 분석해주세요.
 위치: {place_name}
-촬영일자: {captured_at}
+촬영일자: {captured_at or "정보 없음"}
 피복분류: {land_cover_summary}
 
 다음을 포함하여 2-3문장으로 설명해주세요:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-descriptor"
-version = "0.3.0"
+version = "0.3.1"
 description = "Image Descriptor Service for COGnito - generates rich descriptions for satellite imagery"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- `captured_at` 필드를 optional로 변경하여 촬영일자 없이도 설명 생성 가능
- Describer, Context 모듈에서 `None` 값 graceful 처리
- 버전 0.3.1 범프 및 CHANGELOG.md 추가

## Test plan
- [ ] `captured_at` 없이 `/describe` 요청 시 정상 응답 확인
- [ ] `captured_at` 포함 요청 시 기존 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)