### PR TITLE
fix: sync uv.lock version to 0.3.1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -217,7 +217,7 @@ wheels = [
 
 [[package]]
 name = "cognito-descriptor"
-version = "0.2.0"
+version = "0.3.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- uv.lock 버전을 pyproject.toml(0.3.1)과 동기화

## Test plan
- [x] `uv lock` 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)