### PR TITLE
fix: anchor version grep in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         if: steps.bump.outputs.skip != 'true'
         id: version
         run: |
-          CURRENT=$(grep -oP 'version = "\K[^"]+' pyproject.toml)
+          CURRENT=$(grep -oP '^version = "\K[^"]+' pyproject.toml)
           IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
           case "${{ steps.bump.outputs.type }}" in
             major) MAJOR=$((MAJOR+1)); MINOR=0; PATCH=0 ;;


### PR DESCRIPTION
## Summary
- `release.yml`의 버전 파싱 grep에 `^` 앵커 추가
- `target-version` 등 다른 필드가 매칭되는 버그 수정 (PR #15 머지 시 실패 원인)

## Test plan
- [x] `grep -oP '^version = "\K[^"]+' pyproject.toml` → `0.3.1`만 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)