### PR TITLE
fix: convert RGBA to RGB before JPEG encoding

### DIFF
--- a/app/modules/describer.py
+++ b/app/modules/describer.py
@@ -38,6 +38,8 @@ def _resize_for_gemini(image_bytes: bytes, max_size: int) -> bytes:
     img = Image.open(io.BytesIO(image_bytes))
     if max(img.size) > max_size:
         img.thumbnail((max_size, max_size), Image.LANCZOS)
+    if img.mode == "RGBA":
+        img = img.convert("RGB")
     buf = io.BytesIO()
     img.save(buf, format="JPEG", quality=85)
     return buf.getvalue()


### PR DESCRIPTION
## Summary
- PNG 썸네일(RGBA)을 JPEG 변환 시 "cannot write mode RGBA as JPEG" 오류 수정
- `_resize_for_gemini`에서 RGBA → RGB 변환 추가
- 단위 테스트 추가

## Test plan
- [x] `test_resize_for_gemini_rgba_to_rgb` 통과 확인
- [ ] 배포 후 동일 요청으로 description 정상 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)