### PR TITLE
fix: pin Gemini model to gemini-2.0-flash-001

### DIFF
--- a/app/modules/describer.py
+++ b/app/modules/describer.py
@@ -111,7 +111,7 @@ async def describe_image(
 
     client = genai.Client(api_key=settings.google_ai_api_key)
     response = client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.0-flash-001",
         contents=[
             genai.types.Part.from_bytes(data=image_bytes, mime_type="image/jpeg"),
             prompt,


### PR DESCRIPTION
## Summary
- `gemini-2.0-flash` alias가 신규 사용자에게 더 이상 사용 불가
- `gemini-2.0-flash-001`로 고정하여 안정성 확보

## Test plan
- [ ] 배포 후 /api/describe 요청에서 description 정상 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)