### PR TITLE
fix: switch to gemini-2.5-flash model

### DIFF
--- a/app/modules/describer.py
+++ b/app/modules/describer.py
@@ -111,7 +111,7 @@ async def describe_image(
 
     client = genai.Client(api_key=settings.google_ai_api_key)
     response = client.models.generate_content(
-        model="gemini-2.0-flash-001",
+        model="gemini-2.5-flash",
         contents=[
             genai.types.Part.from_bytes(data=image_bytes, mime_type="image/jpeg"),
             prompt,


### PR DESCRIPTION
## Summary
- `gemini-2.0-flash-001`도 deprecated → `gemini-2.5-flash`로 변경

## Test plan
- [ ] 배포 후 /api/describe에서 description 정상 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)