### PR TITLE
fix: convert any non-RGB mode to RGB before JPEG

### DIFF
--- a/app/modules/describer.py
+++ b/app/modules/describer.py
@@ -38,7 +38,7 @@ def _resize_for_gemini(image_bytes: bytes, max_size: int) -> bytes:
     img = Image.open(io.BytesIO(image_bytes))
     if max(img.size) > max_size:
         img.thumbnail((max_size, max_size), Image.LANCZOS)
-    if img.mode == "RGBA":
+    if img.mode != "RGB":
         img = img.convert("RGB")
     buf = io.BytesIO()
     img.save(buf, format="JPEG", quality=85)

--- a/tests/test_describer.py
+++ b/tests/test_describer.py
@@ -80,9 +80,10 @@ def test_validate_thumbnail_url_allows_public_ip(mock_dns):
     _validate_thumbnail_url("https://example.com/image.png")
 
 
-def test_resize_for_gemini_rgba_to_rgb():
-    """RGBA PNG should be converted to RGB JPEG without error."""
-    img = Image.new("RGBA", (100, 100), (255, 0, 0, 128))
+@pytest.mark.parametrize("mode", ["RGBA", "P", "LA"])
+def test_resize_for_gemini_converts_non_rgb_to_rgb(mode):
+    """Non-RGB images should be converted to RGB JPEG without error."""
+    img = Image.new(mode, (100, 100))
     buf = io.BytesIO()
     img.save(buf, format="PNG")
     result = _resize_for_gemini(buf.getvalue(), 200)


### PR DESCRIPTION
## Summary
- RGBA만 체크하던 것을 `img.mode != "RGB"` 조건으로 확장
- P, LA 등 다른 모드에서도 JPEG 저장 실패 방지
- 테스트를 parametrize로 RGBA, P, LA 모드 커버

## Test plan
- [x] `pytest tests/test_describer.py` — 9 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)