### PR TITLE
fix: disable Gemini thinking to prevent output truncation

### DIFF
--- a/app/modules/describer.py
+++ b/app/modules/describer.py
@@ -116,7 +116,10 @@ async def describe_image(
             genai.types.Part.from_bytes(data=image_bytes, mime_type="image/jpeg"),
             prompt,
         ],
-        config={"max_output_tokens": 300},
+        config={
+            "max_output_tokens": 300,
+            "thinking_config": {"thinking_budget": 0},
+        },
     )
 
     description = response.text.strip()


### PR DESCRIPTION
## Summary
- Gemini 2.5 Flash의 thinking 토큰이 `max_output_tokens` 예산을 소진하여 응답이 11글자로 잘리는 문제 수정
- `thinking_budget: 0`으로 thinking 비활성화

## Test plan
- [ ] 배포 후 /api/describe에서 2-3문장 description 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)