### PR TITLE
feat: add bbox coverage info to Gemini prompt

### DIFF
--- a/app/services/composer.py
+++ b/app/services/composer.py
@@ -39,6 +39,7 @@ async def compose_description(request: DescribeRequest, cache: CacheStore) -> De
             lc_summary,
             cache,
             request.cog_image_id,
+            request.bbox,
             warnings,
         )
     )
@@ -88,7 +89,7 @@ async def _safe_landcover(lon, lat, cache, warnings):
 
 
 async def _safe_describe(
-    thumbnail, place_name, captured_at, lc_summary, cache, cog_image_id, warnings
+    thumbnail, place_name, captured_at, lc_summary, cache, cog_image_id, bbox, warnings
 ):
     cb = _breakers["describer"]
     if cb.is_open:
@@ -96,7 +97,7 @@ async def _safe_describe(
         return None
     try:
         result = await describer.describe_image(
-            thumbnail, place_name, captured_at, lc_summary, cache, cog_image_id
+            thumbnail, place_name, captured_at, lc_summary, cache, cog_image_id, bbox
         )
         cb.record_success()
         return result

--- a/tests/test_describer.py
+++ b/tests/test_describer.py
@@ -22,6 +22,13 @@ def test_make_prompt():
     assert "한국어" in prompt
 
 
+def test_make_prompt_with_bbox():
+    bbox = [126.0, 37.0, 127.0, 38.0]
+    prompt = _make_prompt("서울", "2025-06-15", "주거지역 50%", bbox=bbox)
+    assert "km" in prompt
+    assert "영상 범위" in prompt
+
+
 @pytest.fixture
 async def cache(tmp_path):
     store = CacheStore(str(tmp_path / "test.db"))


### PR DESCRIPTION
## Summary
- bbox를 프롬프트에 전달하여 영상 커버리지 범위(km×km) 표시
- "영상 전체를 아우르는 관점" 지시 추가
- 중심점만 언급하던 설명이 넓은 영역 전체를 설명하도록 개선

## Test plan
- [x] `pytest tests/test_describer.py` — 10 passed
- [ ] 배포 후 /api/describe에서 넓은 범위를 언급하는 description 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)