### PR TITLE
fix: increase max_output_tokens to prevent truncation

### DIFF
--- a/app/modules/describer.py
+++ b/app/modules/describer.py
@@ -147,7 +147,7 @@ async def describe_image(
             prompt,
         ],
         config={
-            "max_output_tokens": 300,
+            "max_output_tokens": 600,
             "thinking_config": {"thinking_budget": 0},
         },
     )


### PR DESCRIPTION
## Summary
- `max_output_tokens`를 300 → 600으로 증가
- bbox 커버리지 정보 추가 후 Gemini가 더 상세한 응답을 생성하면서 잘리는 문제 수정

## Test plan
- [ ] 배포 후 description이 완전한 문장으로 끝나는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)