### PR TITLE
release: v0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-descriptor"
-version = "0.3.1"
+version = "0.4.0"
 description = "Image Descriptor Service for COGnito - generates rich descriptions for satellite imagery"
 requires-python = ">=3.11"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -217,7 +217,7 @@ wheels = [
 
 [[package]]
 name = "cognito-descriptor"
-version = "0.3.1"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- Bump version to 0.4.0

## Changelog (since v0.3.1)

### Breaking Changes
- 좌표 검증 실패 시 HTTP 400 → 422 응답 코드 변경 (Pydantic validation)

### Features
- bbox coverage 정보를 Gemini 프롬프트에 추가 (#23)

### Refactoring
- `_safe_*` 함수를 `_safe_call` 제네릭 래퍼로 통합 (#30)
- 좌표 검증을 Pydantic `field_validator`로 이동, routes.py 중복 제거 (#31)

### Bug Fixes
- geocoder, landcover, context 모듈 개선 (#26)
- max_output_tokens 600으로 증가하여 truncation 방지 (#25)
- lint long line 수정 (#24)
- Gemini 프롬프트에 현재 날짜 추가 (#22)
- Gemini 2.5 Flash thinking 비활성화 (#21)
- 비-RGB 이미지 모드를 RGB로 변환 (#20)
- gemini-2.5-flash 모델로 전환 (#19)
- gemini-2.0-flash-001 고정 모델 버전 사용 (#18)
- RGBA→RGB 변환 후 JPEG 인코딩 (#17)
- 릴리스 워크플로우 버전 grep 수정 (#16)
- uv.lock 버전 동기화 (#15)
- 자동 릴리스 워크플로우 추가 (#14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)