### PR TITLE
fix: add bbox coordinate range validation

### DIFF
--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -17,6 +17,22 @@ class DescribeRequest(BaseModel):
     bbox: list[float] | None = Field(
         None, description="[west, south, east, north]", min_length=4, max_length=4
     )
+
+    @field_validator("bbox")
+    @classmethod
+    def validate_bbox(cls, v: list[float] | None) -> list[float] | None:
+        if v is None:
+            return v
+        west, south, east, north = v
+        if not (-180 <= west <= 180) or not (-180 <= east <= 180):
+            raise ValueError("Longitude must be between -180 and 180")
+        if not (-90 <= south <= 90) or not (-90 <= north <= 90):
+            raise ValueError("Latitude must be between -90 and 90")
+        if west >= east:
+            raise ValueError("west must be less than east")
+        if south >= north:
+            raise ValueError("south must be less than north")
+        return v
     captured_at: str | None = Field(None, description="Capture date in ISO 8601 format")
     cog_image_id: str | None = Field(None, description="Optional cog_images UUID for DB linking")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -46,6 +46,39 @@ async def test_describe_invalid_coordinates(client):
     assert resp.status_code == 422
 
 
+@pytest.mark.parametrize(
+    "bbox",
+    [
+        [999, 0, 10, 10],        # west out of range
+        [0, -100, 10, 10],       # south out of range
+        [10, 0, 5, 10],          # west >= east
+        [0, 10, 10, 5],          # south >= north
+    ],
+)
+async def test_describe_invalid_bbox(client, bbox):
+    resp = await client.post(
+        "/api/describe",
+        json={
+            "thumbnail": "dGVzdA==",
+            "coordinates": [126.978, 37.566],
+            "bbox": bbox,
+        },
+        headers={"X-API-Key": os.environ["API_KEY"]},
+    )
+    assert resp.status_code == 422
+
+
+def test_describe_bbox_null_accepted():
+    from app.api.schemas import DescribeRequest
+
+    req = DescribeRequest(
+        thumbnail="dGVzdA==",
+        coordinates=[126.978, 37.566],
+        bbox=None,
+    )
+    assert req.bbox is None
+
+
 async def test_describe_thumbnail_too_large(client):
     resp = await client.post(
         "/api/describe",


### PR DESCRIPTION
## Summary
- `schemas.py`에 bbox용 `field_validator` 추가: west/east (-180~180), south/north (-90~90) 범위 검증
- west < east, south < north 순서 검증
- bbox=null 요청은 기존대로 정상 동작

## Test plan
- [x] 유효하지 않은 bbox 값 4가지 케이스에 대해 422 반환 확인
- [x] bbox=null 요청 정상 동작 확인
- [x] 기존 테스트 전체 통과 (16/16)

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)