### PR TITLE
feat: update /health endpoint with dynamic version

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,3 +1,5 @@
+from importlib.metadata import PackageNotFoundError, version
+
 from fastapi import APIRouter, Depends, Request
 from slowapi import Limiter
 
@@ -20,7 +22,11 @@ limiter = Limiter(key_func=get_real_ip)
 
 @router.get("/health")
 async def health():
-    return {"status": "ok", "version": "0.3.0"}
+    try:
+        ver = version("cognito-descriptor")
+    except PackageNotFoundError:
+        ver = "unknown"
+    return {"status": "ok", "version": ver}
 
 
 @router.post("/describe", response_model=DescribeResponse)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,7 +18,9 @@ async def client():
 async def test_health(client):
     resp = await client.get("/api/health")
     assert resp.status_code == 200
-    assert resp.json()["status"] == "ok"
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert "version" in data
 
 
 async def test_describe_no_api_key(client):


### PR DESCRIPTION
## Summary
- `/health` 엔드포인트의 하드코딩된 버전("0.3.0")을 `importlib.metadata`를 통해 동적으로 읽도록 변경
- 패키지 미설치 환경에서도 "unknown"으로 graceful fallback
- 테스트에 version 필드 존재 여부 검증 추가

## Test plan
- [x] `GET /health` → 200, `status: "ok"`, `version` 필드 존재 확인
- [x] 기존 테스트 전체 통과 (11/11)

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)