### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-descriptor"
-version = "0.3.1"
+version = "0.4.0"
 description = "Image Descriptor Service for COGnito - generates rich descriptions for satellite imagery"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- Sprint 2 릴리스를 위해 버전을 0.3.1 → 0.4.0으로 업데이트

## Changes in v0.4.0
- feat: `/health` 엔드포인트 동적 버전 읽기 (#36)
- fix: bbox 좌표 범위 검증 추가 (#35)

Generated with [Claude Code](https://claude.com/claude-code)