### PR TITLE
feat: API 응답 캐시 히트율 모니터링 엔드포인트

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -20,6 +20,12 @@ router = APIRouter()
 limiter = Limiter(key_func=get_real_ip)
 
 
+@router.get("/cache/stats")
+async def cache_stats(request: Request):
+    cache = request.app.state.cache
+    return await cache.stats()
+
+
 @router.get("/health")
 async def health():
     try:

--- a/app/cache/store.py
+++ b/app/cache/store.py
@@ -1,5 +1,6 @@
 import json
 import time
+from collections import defaultdict
 
 import aiosqlite
 
@@ -8,6 +9,8 @@ class CacheStore:
     def __init__(self, db_path: str):
         self._db_path = db_path
         self._db: aiosqlite.Connection | None = None
+        self._hits: dict[str, int] = defaultdict(int)
+        self._misses: dict[str, int] = defaultdict(int)
 
     async def init(self):
         self._db = await aiosqlite.connect(self._db_path)
@@ -20,18 +23,25 @@ class CacheStore:
         """)
         await self._db.commit()
 
+    def _module_from_key(self, key: str) -> str:
+        return key.split(":")[0] if ":" in key else "unknown"
+
     async def get(self, key: str) -> dict | None:
+        module = self._module_from_key(key)
         async with self._db.execute(
             "SELECT value, expires_at FROM cache WHERE key = ?", (key,)
         ) as cursor:
             row = await cursor.fetchone()
         if row is None:
+            self._misses[module] += 1
             return None
         value, expires_at = row
         if expires_at and time.time() > expires_at:
             await self._db.execute("DELETE FROM cache WHERE key = ?", (key,))
             await self._db.commit()
+            self._misses[module] += 1
             return None
+        self._hits[module] += 1
         return json.loads(value)
 
     async def set(self, key: str, value: dict, ttl_days: int | None = None):
@@ -41,6 +51,35 @@ class CacheStore:
             (key, json.dumps(value, ensure_ascii=False), expires_at),
         )
         await self._db.commit()
+
+    async def stats(self) -> dict:
+        async with self._db.execute("SELECT COUNT(*) FROM cache") as cursor:
+            row = await cursor.fetchone()
+            entry_count = row[0]
+
+        async with self._db.execute(
+            "SELECT SUM(LENGTH(key) + LENGTH(value)) FROM cache"
+        ) as cursor:
+            row = await cursor.fetchone()
+            total_bytes = row[0] or 0
+
+        modules = sorted(set(list(self._hits.keys()) + list(self._misses.keys())))
+        per_module = {}
+        for m in modules:
+            hits = self._hits.get(m, 0)
+            misses = self._misses.get(m, 0)
+            total = hits + misses
+            per_module[m] = {
+                "hits": hits,
+                "misses": misses,
+                "hit_rate": round(hits / total, 4) if total > 0 else 0.0,
+            }
+
+        return {
+            "entry_count": entry_count,
+            "total_bytes": total_bytes,
+            "modules": per_module,
+        }
 
     async def close(self):
         if self._db:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,7 @@ import os
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from app.cache.store import CacheStore
 from app.main import app
 
 
@@ -13,6 +14,19 @@ async def client():
         base_url="http://test",
     ) as c:
         yield c
+
+
+@pytest.fixture
+async def client_with_cache(tmp_path):
+    cache = CacheStore(str(tmp_path / "test.db"))
+    await cache.init()
+    app.state.cache = cache
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as c:
+        yield c
+    await cache.close()
 
 
 async def test_health(client):
@@ -122,3 +136,33 @@ async def test_valid_coordinates_require_auth_on_sub_endpoints(client, endpoint)
         },
     )
     assert resp.status_code == 401
+
+
+async def test_cache_stats_endpoint(client_with_cache):
+    resp = await client_with_cache.get("/api/cache/stats")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "entry_count" in data
+    assert "total_bytes" in data
+    assert "modules" in data
+    assert data["entry_count"] == 0
+    assert data["modules"] == {}
+
+
+async def test_cache_stats_after_hit_miss(client_with_cache):
+    cache = app.state.cache
+    # miss
+    result = await cache.get("geocode:127:37")
+    assert result is None
+    # set + hit
+    await cache.set("geocode:127:37", {"place": "Seoul"})
+    result = await cache.get("geocode:127:37")
+    assert result is not None
+
+    resp = await client_with_cache.get("/api/cache/stats")
+    data = resp.json()
+    assert data["entry_count"] == 1
+    geocode_stats = data["modules"]["geocode"]
+    assert geocode_stats["hits"] == 1
+    assert geocode_stats["misses"] == 1
+    assert geocode_stats["hit_rate"] == 0.5


### PR DESCRIPTION
## Summary
- `CacheStore`에 모듈별 in-memory hit/miss 카운터 추가
- `GET /api/cache/stats` 엔드포인트 추가 (인증 불필요)
- 응답: entry_count, total_bytes, 모듈별 hits/misses/hit_rate

## Test plan
- [x] `pytest tests/test_api.py` 전체 18개 통과
- [x] `ruff check` 통과
- [x] stats 엔드포인트 응답 형식 검증
- [x] 캐시 hit/miss 후 카운터 증가 검증

closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)