### PR TITLE
chore: bump version to 0.6.0 for Sprint 4 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-descriptor"
-version = "0.5.0"
+version = "0.6.0"
 description = "Image Descriptor Service for COGnito - generates rich descriptions for satellite imagery"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- Sprint 4 릴리스를 위한 버전 범프 (0.5.0 → 0.6.0)

## Sprint 4 변경사항
- API rate limiting 미들웨어 (#44, PR #45)
- 구조화된 JSON 로깅 with request_id tracking (#43, PR #46)

🤖 Generated with [Claude Code](https://claude.com/claude-code)