### PR TITLE
test: add unit tests for rate limiting, logging, cache stats

### DIFF
--- a/tests/test_cache_stats.py
+++ b/tests/test_cache_stats.py
@@ -1,0 +1,126 @@
+import time
+from unittest.mock import patch
+
+import pytest
+
+from app.cache.store import CacheStore
+
+
+@pytest.fixture
+async def cache(tmp_path):
+    store = CacheStore(str(tmp_path / "cache.db"))
+    await store.init()
+    yield store
+    await store.close()
+
+
+class TestCacheStore:
+    async def test_get_returns_none_for_missing_key(self, cache):
+        result = await cache.get("geocode:0:0")
+        assert result is None
+
+    async def test_set_and_get(self, cache):
+        await cache.set("geocode:127:37", {"place": "Seoul"})
+        result = await cache.get("geocode:127:37")
+        assert result == {"place": "Seoul"}
+
+    async def test_expired_entry_returns_none(self, cache):
+        await cache.set("geocode:1:1", {"x": 1}, ttl_days=1)
+        # Simulate expiration
+        future = time.time() + 2 * 86400
+        with patch("app.cache.store.time") as mock_time:
+            mock_time.time.return_value = future
+            result = await cache.get("geocode:1:1")
+        assert result is None
+
+    async def test_ttl_none_means_no_expiration(self, cache):
+        await cache.set("geocode:2:2", {"x": 2}, ttl_days=None)
+        result = await cache.get("geocode:2:2")
+        assert result == {"x": 2}
+
+    async def test_overwrite_existing_key(self, cache):
+        await cache.set("geocode:3:3", {"v": 1})
+        await cache.set("geocode:3:3", {"v": 2})
+        result = await cache.get("geocode:3:3")
+        assert result == {"v": 2}
+
+
+class TestCacheStats:
+    async def test_empty_cache_stats(self, cache):
+        stats = await cache.stats()
+        assert stats["entry_count"] == 0
+        assert stats["total_bytes"] == 0
+        assert stats["modules"] == {}
+
+    async def test_stats_entry_count(self, cache):
+        await cache.set("geocode:a", {"x": 1})
+        await cache.set("geocode:b", {"x": 2})
+        await cache.set("landcover:c", {"x": 3})
+        stats = await cache.stats()
+        assert stats["entry_count"] == 3
+
+    async def test_stats_total_bytes_nonzero(self, cache):
+        await cache.set("geocode:a", {"place": "Seoul"})
+        stats = await cache.stats()
+        assert stats["total_bytes"] > 0
+
+    async def test_stats_tracks_hits_and_misses(self, cache):
+        await cache.set("geocode:127:37", {"place": "Seoul"})
+        await cache.get("geocode:127:37")  # hit
+        await cache.get("geocode:0:0")  # miss
+
+        stats = await cache.stats()
+        geocode = stats["modules"]["geocode"]
+        assert geocode["hits"] == 1
+        assert geocode["misses"] == 1
+        assert geocode["hit_rate"] == 0.5
+
+    async def test_stats_multiple_modules(self, cache):
+        await cache.set("geocode:a", {"x": 1})
+        await cache.get("geocode:a")  # hit
+        await cache.get("landcover:a")  # miss
+
+        stats = await cache.stats()
+        assert "geocode" in stats["modules"]
+        assert "landcover" in stats["modules"]
+        assert stats["modules"]["geocode"]["hits"] == 1
+        assert stats["modules"]["landcover"]["misses"] == 1
+
+    async def test_module_from_key_unknown(self, cache):
+        await cache.get("noprefix")  # miss, module = "unknown"
+        stats = await cache.stats()
+        assert "unknown" in stats["modules"]
+
+    async def test_hit_rate_zero_when_all_misses(self, cache):
+        await cache.get("geocode:x")
+        stats = await cache.stats()
+        assert stats["modules"]["geocode"]["hit_rate"] == 0.0
+
+
+class TestCacheStatsEndpoint:
+    @pytest.fixture
+    async def client(self, tmp_path):
+        from httpx import ASGITransport, AsyncClient
+
+        from app.main import app
+
+        store = CacheStore(str(tmp_path / "cache.db"))
+        await store.init()
+        app.state.cache = store
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as c:
+            yield c
+        await store.close()
+
+    async def test_endpoint_returns_200(self, client):
+        resp = await client.get("/api/cache/stats")
+        assert resp.status_code == 200
+
+    async def test_endpoint_json_structure(self, client):
+        resp = await client.get("/api/cache/stats")
+        data = resp.json()
+        assert "entry_count" in data
+        assert "total_bytes" in data
+        assert "modules" in data

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,83 @@
+import logging
+from unittest.mock import patch
+
+import pytest
+import structlog
+from httpx import ASGITransport, AsyncClient
+
+from app.cache.store import CacheStore
+from app.main import app
+from app.utils.logging import generate_request_id, request_id_middleware, setup_logging
+
+
+@pytest.fixture
+async def client(tmp_path):
+    cache = CacheStore(str(tmp_path / "test.db"))
+    await cache.init()
+    app.state.cache = cache
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as c:
+        yield c
+    await cache.close()
+
+
+class TestSetupLogging:
+    def test_configures_structlog(self):
+        setup_logging()
+        logger = structlog.get_logger()
+        assert logger is not None
+
+    def test_respects_log_level(self):
+        with patch("app.utils.logging.settings") as mock_settings:
+            mock_settings.log_level = "DEBUG"
+            setup_logging()
+            logger = structlog.get_logger()
+            assert logger is not None
+
+    def test_invalid_log_level_defaults_to_info(self):
+        with patch("app.utils.logging.settings") as mock_settings:
+            mock_settings.log_level = "INVALID"
+            setup_logging()
+            # Should not raise; falls back to INFO
+
+
+class TestGenerateRequestId:
+    def test_returns_16_char_hex(self):
+        rid = generate_request_id()
+        assert len(rid) == 16
+        int(rid, 16)  # should not raise
+
+    def test_unique_ids(self):
+        ids = {generate_request_id() for _ in range(100)}
+        assert len(ids) == 100
+
+
+class TestRequestIdMiddleware:
+    async def test_response_includes_request_id(self, client):
+        resp = await client.get("/api/health")
+        assert "x-request-id" in resp.headers
+        assert len(resp.headers["x-request-id"]) == 16
+
+    async def test_custom_request_id_passthrough(self, client):
+        custom_id = "my-custom-req-id"
+        resp = await client.get(
+            "/api/health", headers={"X-Request-ID": custom_id}
+        )
+        assert resp.headers["x-request-id"] == custom_id
+
+    async def test_generated_id_is_hex(self, client):
+        resp = await client.get("/api/health")
+        rid = resp.headers["x-request-id"]
+        int(rid, 16)  # should not raise
+
+    async def test_different_requests_get_different_ids(self, client):
+        resp1 = await client.get("/api/health")
+        resp2 = await client.get("/api/health")
+        assert resp1.headers["x-request-id"] != resp2.headers["x-request-id"]
+
+    async def test_security_headers_present(self, client):
+        resp = await client.get("/api/health")
+        assert resp.headers["x-content-type-options"] == "nosniff"
+        assert resp.headers["x-frame-options"] == "DENY"

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,135 @@
+import os
+from unittest.mock import patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.cache.store import CacheStore
+from app.main import app, limiter
+from app.utils.rate_limit import get_real_ip
+
+
+@pytest.fixture
+async def rate_limit_client(tmp_path):
+    cache = CacheStore(str(tmp_path / "test.db"))
+    await cache.init()
+    app.state.cache = cache
+    limiter.reset()
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as c:
+        yield c
+    limiter.reset()
+    await cache.close()
+
+
+class TestGetRealIp:
+    def test_extracts_first_ip_from_forwarded_header(self):
+        from starlette.testclient import TestClient
+        from starlette.requests import Request
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [(b"x-forwarded-for", b"1.2.3.4, 5.6.7.8")],
+        }
+        request = Request(scope)
+        assert get_real_ip(request) == "1.2.3.4"
+
+    def test_returns_single_forwarded_ip(self):
+        from starlette.requests import Request
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [(b"x-forwarded-for", b"10.0.0.1")],
+        }
+        request = Request(scope)
+        assert get_real_ip(request) == "10.0.0.1"
+
+    def test_falls_back_to_client_host(self):
+        from starlette.requests import Request
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [],
+            "client": ("192.168.1.1", 12345),
+        }
+        request = Request(scope)
+        assert get_real_ip(request) == "192.168.1.1"
+
+    def test_returns_localhost_when_no_client(self):
+        from starlette.requests import Request
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [],
+        }
+        request = Request(scope)
+        assert get_real_ip(request) == "127.0.0.1"
+
+
+class TestRateLimitMiddleware:
+    async def test_rate_limit_returns_429(self, rate_limit_client):
+        api_key = os.environ["API_KEY"]
+        headers = {"X-API-Key": api_key}
+        body = {
+            "thumbnail": "dGVzdA==",
+            "coordinates": [126.978, 37.566],
+            "captured_at": "2025-06-15T00:00:00Z",
+        }
+        with patch("app.config.settings.rate_limit", "1/minute"):
+            await rate_limit_client.post("/api/describe", json=body, headers=headers)
+            resp = await rate_limit_client.post(
+                "/api/describe", json=body, headers=headers
+            )
+            assert resp.status_code == 429
+
+    async def test_429_response_body(self, rate_limit_client):
+        api_key = os.environ["API_KEY"]
+        headers = {"X-API-Key": api_key}
+        body = {
+            "thumbnail": "dGVzdA==",
+            "coordinates": [126.978, 37.566],
+            "captured_at": "2025-06-15T00:00:00Z",
+        }
+        with patch("app.config.settings.rate_limit", "1/minute"):
+            await rate_limit_client.post("/api/describe", json=body, headers=headers)
+            resp = await rate_limit_client.post(
+                "/api/describe", json=body, headers=headers
+            )
+            assert resp.status_code == 429
+            data = resp.json()
+            assert "error" in data or "detail" in data
+
+    async def test_health_endpoint_not_rate_limited(self, rate_limit_client):
+        for _ in range(10):
+            resp = await rate_limit_client.get("/api/health")
+            assert resp.status_code == 200
+
+    async def test_rate_limit_per_endpoint(self, rate_limit_client):
+        """Different endpoints have independent rate limits."""
+        api_key = os.environ["API_KEY"]
+        headers = {"X-API-Key": api_key}
+        body = {
+            "thumbnail": "dGVzdA==",
+            "coordinates": [126.978, 37.566],
+            "captured_at": "2025-06-15T00:00:00Z",
+        }
+        with patch("app.config.settings.rate_limit", "1/minute"):
+            # Exhaust describe limit
+            await rate_limit_client.post("/api/describe", json=body, headers=headers)
+            resp = await rate_limit_client.post(
+                "/api/describe", json=body, headers=headers
+            )
+            assert resp.status_code == 429
+            # cache/stats should still work (no rate limit)
+            resp = await rate_limit_client.get("/api/cache/stats")
+            assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Add `tests/test_rate_limit.py`: IP extraction from X-Forwarded-For, 429 rate limit enforcement, per-endpoint isolation, health endpoint bypass (8 tests)
- Add `tests/test_logging.py`: structlog configuration, request_id generation/passthrough, security headers (11 tests)
- Add `tests/test_cache_stats.py`: CacheStore CRUD with TTL, hit/miss tracking, stats endpoint (13 tests)

Total: 32 new tests covering Sprint 3-4 modules (rate limiting, structured logging, cache stats)

closes #49

## Test plan
- [x] All 32 new tests pass
- [x] Full test suite (85 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)