### PR TITLE
chore: bump version to 0.7.0 for Sprint 7 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-descriptor"
-version = "0.6.0"
+version = "0.7.0"
 description = "Image Descriptor Service for COGnito - generates rich descriptions for satellite imagery"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- Sprint 7 릴리스를 위해 버전을 0.6.0 → 0.7.0으로 업데이트

## Sprint 7 변경사항
- **PR #52**: 외부 API 호출에 tenacity 기반 재시도(retry) 및 circuit breaker 패턴 적용
- **PR #55**: circuit breaker 단위 테스트 24개 및 외부 API 에러 핸들링 테스트 추가 (전체 136개 통과)

Generated with [Claude Code](https://claude.com/claude-code)