### PR TITLE
feat: add mission module with STAC metadata and tests

### DIFF
--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -35,6 +35,7 @@ class DescribeRequest(BaseModel):
         return v
     captured_at: str | None = Field(None, description="Capture date in ISO 8601 format")
     cog_image_id: str | None = Field(None, description="Optional cog_images UUID for DB linking")
+    stac_id: str | None = Field(None, description="STAC item ID for satellite mission metadata")
 
     model_config = {
         "json_schema_extra": {
@@ -115,6 +116,16 @@ class Context(BaseModel):
     summary: str
 
 
+class Mission(BaseModel):
+    platform: str = Field(description="Satellite platform (e.g. Sentinel-2C)")
+    instrument: str = Field(description="Sensor instrument (e.g. MSI)")
+    constellation: str | None = Field(None, description="Mission constellation")
+    processing_level: str | None = Field(None, description="Processing level (e.g. L2A)")
+    cloud_cover: float | None = Field(None, description="Cloud cover percentage")
+    gsd: float | None = Field(None, description="Ground sample distance in meters")
+    spectral_bands: int | None = Field(None, description="Number of spectral bands")
+
+
 class Warning(BaseModel):
     module: str
     error: str
@@ -125,6 +136,7 @@ class DescribeResponse(BaseModel):
     location: Location | None = None
     land_cover: LandCover | None = None
     context: Context | None = None
+    mission: Mission | None = None
     warnings: list[Warning] = []
     cached: bool = False
 

--- a/app/modules/mission.py
+++ b/app/modules/mission.py
@@ -1,0 +1,53 @@
+import httpx
+import structlog
+
+from app.api.schemas import Mission
+from app.cache.store import CacheStore
+from app.utils.retry import retry_http
+
+logger = structlog.get_logger()
+
+STAC_BASE_URL = "https://earth-search.aws.element84.com/v1"
+STAC_COLLECTION = "sentinel-2-c1-l2a"
+
+# Sentinel-2 L2A has 13 spectral bands
+_S2_SPECTRAL_BANDS = 13
+
+
+@retry_http
+async def _fetch_stac_item(stac_id: str) -> httpx.Response:
+    url = f"{STAC_BASE_URL}/collections/{STAC_COLLECTION}/items/{stac_id}"
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url, timeout=10.0)
+        resp.raise_for_status()
+        return resp
+
+
+def _parse_stac_item(data: dict) -> Mission:
+    props = data.get("properties", {})
+    return Mission(
+        platform=props.get("platform", "unknown"),
+        instrument=",".join(props.get("instruments", ["unknown"])),
+        constellation=props.get("constellation"),
+        processing_level=props.get("processing:level"),
+        cloud_cover=props.get("eo:cloud_cover"),
+        gsd=props.get("gsd", 10.0),
+        spectral_bands=_S2_SPECTRAL_BANDS,
+    )
+
+
+async def get_mission_metadata(stac_id: str, cache: CacheStore) -> Mission | None:
+    if not stac_id:
+        return None
+
+    cache_key = f"mission:{stac_id}"
+    cached = await cache.get(cache_key)
+    if cached:
+        logger.debug("mission cache hit", stac_id=stac_id)
+        return Mission(**cached)
+
+    resp = await _fetch_stac_item(stac_id)
+    result = _parse_stac_item(resp.json())
+    await cache.set(cache_key, result.model_dump(), ttl_days=365)
+    logger.info("mission metadata fetched", stac_id=stac_id, platform=result.platform)
+    return result

--- a/app/services/composer.py
+++ b/app/services/composer.py
@@ -5,7 +5,7 @@ import structlog
 
 from app.api.schemas import DescribeRequest, DescribeResponse, Warning
 from app.cache.store import CacheStore
-from app.modules import context, describer, geocoder, landcover
+from app.modules import context, describer, geocoder, landcover, mission
 from app.utils.circuit_breaker import CircuitBreaker
 
 logger = structlog.get_logger()
@@ -16,6 +16,7 @@ _breakers = {
     "landcover": CircuitBreaker("landcover"),
     "describer": CircuitBreaker("describer"),
     "context": CircuitBreaker("context"),
+    "mission": CircuitBreaker("mission"),
 }
 
 
@@ -39,14 +40,22 @@ async def compose_description(request: DescribeRequest, cache: CacheStore) -> De
     warnings: list[Warning] = []
     lon, lat = request.coordinates
 
-    # Phase 1: Geocoder + LandCover 병렬 실행 (Describer의 입력이 됨)
+    # Phase 1: Geocoder + LandCover + Mission 병렬 실행
     geo_task = asyncio.create_task(
         _safe_call("geocoder", geocoder.geocode(lon, lat, cache), warnings)
     )
     lc_task = asyncio.create_task(
         _safe_call("landcover", landcover.get_land_cover(lon, lat, cache), warnings)
     )
-    location, land_cover_result = await asyncio.gather(geo_task, lc_task)
+    mission_task = asyncio.create_task(
+        _safe_call("mission", mission.get_mission_metadata(request.stac_id, cache), warnings)
+    ) if request.stac_id else None
+    phase1_tasks = [geo_task, lc_task]
+    if mission_task:
+        phase1_tasks.append(mission_task)
+    phase1_results = await asyncio.gather(*phase1_tasks)
+    location, land_cover_result = phase1_results[0], phase1_results[1]
+    mission_result = phase1_results[2] if mission_task else None
 
     # Phase 2: Describer + Context 병렬 실행 (Phase 1 결과 활용)
     place_name = location.place_name if location else f"{lat}, {lon}"
@@ -85,6 +94,7 @@ async def compose_description(request: DescribeRequest, cache: CacheStore) -> De
         location=location,
         land_cover=land_cover_result,
         context=context_result,
+        mission=mission_result,
         warnings=warnings,
         cached=False,
     )

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -1,0 +1,255 @@
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from app.api.schemas import Mission
+from app.cache.store import CacheStore
+from app.modules.mission import _parse_stac_item, get_mission_metadata
+
+
+@pytest.fixture
+async def cache(tmp_path):
+    store = CacheStore(str(tmp_path / "test.db"))
+    await store.init()
+    yield store
+    await store.close()
+
+
+SAMPLE_STAC_RESPONSE = {
+    "type": "Feature",
+    "id": "S2C_T52SCG_20260225T022315_L2A",
+    "properties": {
+        "platform": "Sentinel-2C",
+        "instruments": ["msi"],
+        "constellation": "Sentinel-2",
+        "processing:level": "L2A",
+        "eo:cloud_cover": 0.48,
+        "gsd": 10.0,
+        "datetime": "2026-02-25T02:23:15Z",
+        "s2:datatake_type": "INS-NOBS",
+        "view:sun_elevation": 35.2,
+    },
+}
+
+
+class TestParseStacItem:
+    def test_parse_full_response(self):
+        result = _parse_stac_item(SAMPLE_STAC_RESPONSE)
+        assert result.platform == "Sentinel-2C"
+        assert result.instrument == "msi"
+        assert result.constellation == "Sentinel-2"
+        assert result.processing_level == "L2A"
+        assert result.cloud_cover == 0.48
+        assert result.gsd == 10.0
+        assert result.spectral_bands == 13
+
+    def test_parse_missing_optional_fields(self):
+        data = {"properties": {"platform": "Sentinel-2A", "instruments": ["msi"]}}
+        result = _parse_stac_item(data)
+        assert result.platform == "Sentinel-2A"
+        assert result.constellation is None
+        assert result.processing_level is None
+        assert result.cloud_cover is None
+
+    def test_parse_empty_properties(self):
+        result = _parse_stac_item({"properties": {}})
+        assert result.platform == "unknown"
+        assert result.instrument == "unknown"
+
+    def test_parse_multiple_instruments(self):
+        data = {"properties": {"platform": "test", "instruments": ["msi", "olci"]}}
+        result = _parse_stac_item(data)
+        assert result.instrument == "msi,olci"
+
+
+class TestGetMissionMetadata:
+    async def test_returns_none_for_empty_stac_id(self, cache):
+        result = await get_mission_metadata("", cache)
+        assert result is None
+
+    async def test_returns_none_for_none_stac_id(self, cache):
+        result = await get_mission_metadata(None, cache)
+        assert result is None
+
+    @patch("app.modules.mission._fetch_stac_item")
+    async def test_fetches_and_caches(self, mock_fetch, cache):
+        mock_resp = AsyncMock(spec=httpx.Response)
+        mock_resp.json.return_value = SAMPLE_STAC_RESPONSE
+        mock_fetch.return_value = mock_resp
+
+        stac_id = "S2C_T52SCG_20260225T022315_L2A"
+        result = await get_mission_metadata(stac_id, cache)
+
+        assert result.platform == "Sentinel-2C"
+        assert result.cloud_cover == 0.48
+        mock_fetch.assert_called_once_with(stac_id)
+
+        # Second call should use cache
+        mock_fetch.reset_mock()
+        result2 = await get_mission_metadata(stac_id, cache)
+        assert result2.platform == "Sentinel-2C"
+        mock_fetch.assert_not_called()
+
+    @patch("app.modules.mission._fetch_stac_item")
+    async def test_cache_miss_then_hit(self, mock_fetch, cache):
+        mock_resp = AsyncMock(spec=httpx.Response)
+        mock_resp.json.return_value = SAMPLE_STAC_RESPONSE
+        mock_fetch.return_value = mock_resp
+
+        stac_id = "S2C_TEST_ID"
+        await get_mission_metadata(stac_id, cache)
+
+        # Verify cache was populated
+        cached = await cache.get(f"mission:{stac_id}")
+        assert cached is not None
+        assert cached["platform"] == "Sentinel-2C"
+
+    @patch("app.modules.mission._fetch_stac_item")
+    async def test_network_error_propagates(self, mock_fetch, cache):
+        mock_fetch.side_effect = httpx.ConnectError("Connection refused")
+
+        with pytest.raises(httpx.ConnectError):
+            await get_mission_metadata("bad-id", cache)
+
+    @patch("app.modules.mission._fetch_stac_item")
+    async def test_http_404_propagates(self, mock_fetch, cache):
+        mock_fetch.side_effect = httpx.HTTPStatusError(
+            "Not Found",
+            request=httpx.Request("GET", "http://test"),
+            response=httpx.Response(404),
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await get_mission_metadata("nonexistent-id", cache)
+
+
+class TestMissionInComposer:
+    """Test mission module integration in composer."""
+
+    @patch("app.services.composer.mission")
+    @patch("app.services.composer.context")
+    @patch("app.services.composer.describer")
+    @patch("app.services.composer.landcover")
+    @patch("app.services.composer.geocoder")
+    async def test_compose_with_stac_id(
+        self, mock_geo, mock_lc, mock_desc, mock_ctx, mock_mission, cache
+    ):
+        from app.api.schemas import (
+            Context,
+            DescribeRequest,
+            LandCover,
+            LandCoverClass,
+            Location,
+        )
+        from app.services.composer import compose_description
+
+        mock_geo.geocode = AsyncMock(
+            return_value=Location(
+                country="대한민국", country_code="kr", region="서울",
+                city="중구", place_name="서울특별시", lat=37.566, lon=126.978,
+            )
+        )
+        mock_lc.get_land_cover = AsyncMock(
+            return_value=LandCover(
+                classes=[LandCoverClass(type="residential", label="주거지역", percentage=60)],
+                summary="주거지역 60%",
+            )
+        )
+        mock_desc.describe_image = AsyncMock(return_value="설명")
+        mock_ctx.research_context = AsyncMock(
+            return_value=Context(events=[], summary="없음")
+        )
+        mock_mission.get_mission_metadata = AsyncMock(
+            return_value=Mission(
+                platform="Sentinel-2C", instrument="msi",
+                constellation="Sentinel-2", processing_level="L2A",
+                cloud_cover=0.48, gsd=10.0, spectral_bands=13,
+            )
+        )
+
+        request = DescribeRequest(
+            thumbnail="dGVzdA==",
+            coordinates=[126.978, 37.566],
+            captured_at="2025-06-15T00:00:00Z",
+            stac_id="S2C_T52SCG_20260225T022315_L2A",
+        )
+        result = await compose_description(request, cache)
+
+        assert result.mission is not None
+        assert result.mission.platform == "Sentinel-2C"
+        assert result.mission.cloud_cover == 0.48
+        mock_mission.get_mission_metadata.assert_called_once()
+
+    @patch("app.services.composer.mission")
+    @patch("app.services.composer.context")
+    @patch("app.services.composer.describer")
+    @patch("app.services.composer.landcover")
+    @patch("app.services.composer.geocoder")
+    async def test_compose_without_stac_id(
+        self, mock_geo, mock_lc, mock_desc, mock_ctx, mock_mission, cache
+    ):
+        from app.api.schemas import Context, DescribeRequest, LandCover, Location
+        from app.services.composer import compose_description
+
+        mock_geo.geocode = AsyncMock(
+            return_value=Location(
+                country="대한민국", country_code="kr", region="서울",
+                city="중구", place_name="서울특별시", lat=37.566, lon=126.978,
+            )
+        )
+        mock_lc.get_land_cover = AsyncMock(
+            return_value=LandCover(classes=[], summary="정보 없음")
+        )
+        mock_desc.describe_image = AsyncMock(return_value="설명")
+        mock_ctx.research_context = AsyncMock(
+            return_value=Context(events=[], summary="없음")
+        )
+
+        request = DescribeRequest(
+            thumbnail="dGVzdA==",
+            coordinates=[126.978, 37.566],
+        )
+        result = await compose_description(request, cache)
+
+        assert result.mission is None
+        mock_mission.get_mission_metadata.assert_not_called()
+
+    @patch("app.services.composer.mission")
+    @patch("app.services.composer.context")
+    @patch("app.services.composer.describer")
+    @patch("app.services.composer.landcover")
+    @patch("app.services.composer.geocoder")
+    async def test_compose_mission_failure_graceful(
+        self, mock_geo, mock_lc, mock_desc, mock_ctx, mock_mission, cache
+    ):
+        from app.api.schemas import Context, DescribeRequest, LandCover, Location
+        from app.services.composer import compose_description
+
+        mock_geo.geocode = AsyncMock(
+            return_value=Location(
+                country="대한민국", country_code="kr", region="서울",
+                city="중구", place_name="서울특별시", lat=37.566, lon=126.978,
+            )
+        )
+        mock_lc.get_land_cover = AsyncMock(
+            return_value=LandCover(classes=[], summary="정보 없음")
+        )
+        mock_desc.describe_image = AsyncMock(return_value="설명")
+        mock_ctx.research_context = AsyncMock(
+            return_value=Context(events=[], summary="없음")
+        )
+        mock_mission.get_mission_metadata = AsyncMock(
+            side_effect=Exception("STAC API down")
+        )
+
+        request = DescribeRequest(
+            thumbnail="dGVzdA==",
+            coordinates=[126.978, 37.566],
+            stac_id="bad-id",
+        )
+        result = await compose_description(request, cache)
+
+        assert result.mission is None
+        assert result.description == "설명"
+        assert any(w.module == "mission" for w in result.warnings)


### PR DESCRIPTION
## Summary
- `app/modules/mission.py`: Element84 STAC API에서 위성 미션 메타데이터 조회 (platform, instrument, cloud_cover 등)
- `DescribeRequest`에 `stac_id` 필드 추가, `DescribeResponse`에 `mission` 필드 추가
- composer Phase 1에서 geocoder/landcover와 병렬로 mission 실행
- `stac_id` 미제공 시 `mission: null` 반환 (하위 호환 유지)
- 13개 테스트: 파싱 4건, 캐시/에러 6건, composer 통합 3건

closes #58

## Test plan
- [x] mission 모듈 단위 테스트 13건 통과
- [x] 기존 composer 테스트 12건 통과 (하위 호환성 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)