### PR TITLE
chore: bump version to 0.7.1 for Sprint 8 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-descriptor"
-version = "0.7.0"
+version = "0.7.1"
 description = "Image Descriptor Service for COGnito - generates rich descriptions for satellite imagery"
 requires-python = ">=3.11"
 dependencies = [

--- a/sprint-logs/sprint-8.md
+++ b/sprint-logs/sprint-8.md
@@ -1,0 +1,29 @@
+# Sprint 8 결과 요약
+
+**기간**: 2026-03-05
+**릴리스**: v0.7.1 (패치)
+
+## 완료 이슈
+
+| 이슈 | 제목 | PR |
+|------|------|-----|
+| #57 | perf: 모듈 병렬 실행 최적화 (asyncio.gather) | #59 |
+
+## 미완료 이슈
+
+| 이슈 | 제목 | PR | 상태 |
+|------|------|-----|------|
+| #58 | test: mission 모듈 단위 테스트 및 STAC API 통합 테스트 | #60 | 변경 요청 |
+| #27 | feat: 위성 미션 메타데이터 제공 (STAC 연동) | - | 진행 중 |
+| #61 | fix: mission 모듈 타입 어노테이션 및 빈 instruments 엣지 케이스 수정 | - | 신규 |
+
+## 주요 변경사항
+
+### Phase 타이밍 로그 (PR #59)
+- `compose_description`에 `time.monotonic()` 기반 Phase 1/Phase 2/전체 실행 시간 측정 로그 추가
+- structlog 구조화 필드: `phase1_duration_ms`, `phase2_duration_ms`, `total_duration_ms`
+- 타이밍 로그 검증 테스트 추가
+
+## 다음 스프린트 과제
+- PR #60 리뷰 피드백 반영 (이슈 #61) 후 머지
+- 이슈 #27 (STAC 연동) 완료


### PR DESCRIPTION
## Summary
- Version bump 0.7.0 → 0.7.1
- Sprint 8 결과 요약 로그 추가

## Sprint 8 완료 내역
- PR #59: Phase 타이밍 로그 추가 (이슈 #57)

## 미완료
- PR #60 (mission 모듈): 리뷰 변경 요청 반영 필요 (이슈 #61)

🤖 Generated with [Claude Code](https://claude.com/claude-code)