### PR TITLE
refactor: move thumbnail validation to Pydantic field_validator (#70)

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -74,14 +74,6 @@ async def describe(
     request: Request,
     _auth: dict = Depends(authenticate),
 ):
-    if not body.thumbnail.startswith("http") and len(body.thumbnail) > 5 * 1024 * 1024:
-        raise DescriptorError(
-            status_code=422,
-            code="THUMBNAIL_TOO_LARGE",
-            message="Thumbnail too large (max 5MB)",
-            details={"size": len(body.thumbnail), "max": 5 * 1024 * 1024},
-        )
-
     cache = request.app.state.cache
     result = await compose_description(body, cache)
 
@@ -123,8 +115,6 @@ async def describe_batch(
 
     async def _process_one(index: int, item: DescribeRequest) -> BatchItemResult:
         try:
-            if not item.thumbnail.startswith("http") and len(item.thumbnail) > 5 * 1024 * 1024:
-                return BatchItemResult(index=index, error="Thumbnail too large (max 5MB)")
             result = await compose_description(item, cache)
             if item.cog_image_id and result.description:
                 await db.save_description(

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -35,6 +35,13 @@ class DescribeRequest(BaseModel):
             raise ValueError("south must be less than north")
         return v
 
+    @field_validator("thumbnail")
+    @classmethod
+    def validate_thumbnail_size(cls, v: str) -> str:
+        if not v.startswith("http") and len(v) > 5 * 1024 * 1024:
+            raise ValueError("Thumbnail too large (max 5MB)")
+        return v
+
     captured_at: str | None = Field(None, description="Capture date in ISO 8601 format")
     cog_image_id: str | None = Field(None, description="Optional cog_images UUID for DB linking")
     stac_id: str | None = Field(None, description="STAC item ID for satellite mission metadata")

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -105,12 +105,7 @@ async def test_batch_no_auth():
     assert resp.status_code == 401
 
 
-@patch(
-    "app.api.routes.compose_description",
-    new_callable=AsyncMock,
-    return_value=_mock_response(),
-)
-async def test_batch_thumbnail_too_large(mock_compose, client_with_cache):
+async def test_batch_thumbnail_too_large(client_with_cache):
     large_item = {
         "thumbnail": "x" * (5 * 1024 * 1024 + 1),
         "coordinates": [126.978, 37.566],
@@ -119,8 +114,4 @@ async def test_batch_thumbnail_too_large(mock_compose, client_with_cache):
         "/api/describe/batch",
         json={"items": [_make_item(), large_item]},
     )
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["succeeded"] == 1
-    assert data["failed"] == 1
-    assert "too large" in data["results"][1]["error"].lower()
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- `DescribeRequest` 모델에 `thumbnail` field_validator 추가 (5MB 초과 시 ValueError)
- `/describe` 및 `/describe/batch` 엔드포인트에서 중복 검증 로직 제거
- batch 테스트를 Pydantic 검증 기반으로 업데이트

## Test plan
- [x] 썸네일 크기 초과 시 422 응답 확인
- [x] batch 요청에서 썸네일 크기 초과 시 전체 422 응답 확인
- [x] 기존 180개 테스트 전부 통과

closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)