### PR TITLE
ci: GitHub Actions CI/CD pipeline with matrix testing (#75)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,14 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_call:
 
 jobs:
-  lint-and-test:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,10 +28,34 @@ jobs:
       - name: Format check
         run: uv run ruff format --check .
 
-      - name: Test
-        run: uv run pytest -v
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run tests with coverage
+        run: uv run pytest -v --tb=short --junitxml=test-results.xml
         env:
           GOOGLE_AI_API_KEY: "test-key"
           SUPABASE_URL: "https://test.supabase.co"
           SUPABASE_SERVICE_KEY: "test-key"
           API_KEY: "test-key"
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-py${{ matrix.python-version }}
+          path: test-results.xml


### PR DESCRIPTION
## Summary
- lint와 test를 별도 job으로 분리하여 병렬 실행
- Python 3.11/3.12/3.13 매트릭스 테스트 추가
- main 브랜치 push 트리거 추가
- JUnit XML 테스트 결과 아티팩트 업로드

## Test plan
- [ ] PR 생성 시 CI 자동 실행 확인
- [ ] lint job 통과 확인
- [ ] 3개 Python 버전 test job 통과 확인
- [ ] 테스트 결과 아티팩트 업로드 확인

closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)