### PR TITLE
chore: bump version to 0.11.0 for Sprint 12 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-descriptor"
-version = "0.10.0"
+version = "0.11.0"
 description = "Image Descriptor Service for COGnito - generates rich descriptions for satellite imagery"
 requires-python = ">=3.11"
 dependencies = [

--- a/sprint-logs/sprint-12-6-orchestrator-end.log
+++ b/sprint-logs/sprint-12-6-orchestrator-end.log
@@ -1,0 +1,15 @@
+## 스프린트 12 마무리 완료
+
+| 항목 | 상태 |
+|------|------|
+| PR #76 (Docker 멀티스테이지 빌드 + docker-compose) | ✅ Merged |
+| PR #77 (GitHub Actions CI/CD 파이프라인) | ✅ Merged |
+| PR #73 (썸네일 검증 리팩터링) | ⚠️ 변경 요청 — 다음 스프린트 이월 |
+| 이슈 #71 (Docker) | ✅ Closed |
+| 이슈 #75 (CI/CD) | ✅ Closed |
+
+### 테스트 결과
+- 185 passed, 3 skipped (Python 3.12.3, 29.37s)
+
+### 다음 스프린트 이월 항목
+- **#70 / PR #73**: 썸네일 검증 리팩터링 — 배치 엔드포인트 partial success 동작 복원 필요


### PR DESCRIPTION
## Summary
- Bump version from 0.10.0 to 0.11.0
- Add Sprint 12 end log

## Sprint 12 Changes (included in this release)
- **PR #76**: Docker 멀티스테이지 빌드 + docker-compose 설정
- **PR #77**: GitHub Actions CI/CD 파이프라인 (매트릭스 테스트, 커버리지)

## Test plan
- [ ] CI 파이프라인 통과 확인
- [ ] 버전 번호 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)