### PR TITLE
refactor: Pydantic field_validator로 썸네일 크기 검증 이동

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -4,8 +4,6 @@ from importlib.metadata import PackageNotFoundError, version
 from fastapi import APIRouter, Depends, Request
 from slowapi import Limiter
 
-from pydantic import ValidationError
-
 from app.api.schemas import (
     BatchDescribeItem,
     BatchDescribeRequest,

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -183,7 +183,7 @@ MAX_BATCH_SIZE = 10
 
 
 class BatchDescribeItem(BaseModel):
-    """Batch item without validators — validation deferred to per-item processing."""
+    """Batch item — thumbnail size validation deferred to per-item processing."""
 
     thumbnail: str = Field(description="base64 PNG or URL of lowest pyramid image")
     coordinates: list[float] = Field(


### PR DESCRIPTION
## Summary
- `DescribeRequest` 모델에 `thumbnail` `field_validator` 추가하여 5MB 크기 제한 검증을 모델 레벨로 이동
- `/describe` 및 `/describe/batch` 엔드포인트에서 중복 검증 로직 제거
- 배치 partial success 유지를 위해 `BatchDescribeItem` (validator 없음) 도입, `_process_one`에서 `DescribeRequest.model_validate()`로 개별 검증

## Test plan
- [x] 185 passed, 3 skipped (Sprint 12와 동일)
- [x] `test_describe_thumbnail_too_large` — 단일 엔드포인트 422 반환 확인
- [x] `test_batch_thumbnail_too_large` — 배치 partial success 동작 확인

closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)