### PR TITLE
chore: bump version to 0.11.1 for Sprint 13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-descriptor"
-version = "0.11.0"
+version = "0.11.1"
 description = "Image Descriptor Service for COGnito - generates rich descriptions for satellite imagery"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- Bump version from 0.11.0 to 0.11.1 for Sprint 13 patch release
- Sprint 13 includes refactoring: Pydantic field_validator (#81) and _describe_and_save helper extraction (#82)

🤖 Generated with [Claude Code](https://claude.com/claude-code)