### PR TITLE
feat: add structlog to auth and API routes

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,6 +1,7 @@
 import asyncio
 from importlib.metadata import PackageNotFoundError, version
 
+import structlog
 from fastapi import APIRouter, Depends, Request
 from slowapi import Limiter
 
@@ -22,6 +23,8 @@ from app.db import supabase as db
 from app.services.composer import compose_description
 from app.utils.errors import DescriptorError
 from app.utils.rate_limit import get_real_ip
+
+logger = structlog.get_logger()
 
 router = APIRouter()
 limiter = Limiter(key_func=get_real_ip)
@@ -125,6 +128,9 @@ async def describe_batch(
 
     results = await asyncio.gather(*[_process_one(i, item) for i, item in enumerate(body.items)])
     succeeded = sum(1 for r in results if r.result is not None)
+    logger.info(
+        "batch_complete", total=len(body.items), succeeded=succeeded, failed=len(body.items) - succeeded
+    )
     return BatchDescribeResponse(
         results=list(results),
         total=len(body.items),
@@ -221,6 +227,7 @@ async def get_description(
 ):
     result = await db.get_description(cog_image_id)
     if result is None:
+        logger.info("description_not_found", cog_image_id=cog_image_id)
         raise DescriptorError(
             status_code=404,
             code="NOT_FOUND",

--- a/app/auth.py
+++ b/app/auth.py
@@ -2,12 +2,15 @@ import hmac
 import time
 
 import httpx
+import structlog
 from fastapi import Security
 from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
 
 from app.config import settings
 from app.utils.errors import DescriptorError
+
+logger = structlog.get_logger()
 
 api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 bearer_scheme = HTTPBearer(auto_error=False)
@@ -44,6 +47,7 @@ async def authenticate(
     """Authenticate via API Key or JWT. Returns auth info dict or raises 401."""
     # 1) API Key (timing-safe comparison)
     if api_key and hmac.compare_digest(api_key, settings.api_key):
+        logger.debug("auth_success", auth_type="api_key")
         return {"type": "api_key"}
 
     # 2) Bearer JWT
@@ -51,10 +55,12 @@ async def authenticate(
         try:
             jwks = await _get_jwks()
             payload = _verify_jwt(credentials.credentials, jwks)
+            logger.debug("auth_success", auth_type="jwt", sub=payload["sub"])
             return {"type": "jwt", "sub": payload["sub"]}
         except JWTError:
-            pass
+            logger.warning("auth_jwt_invalid")
 
+    logger.warning("auth_failed")
     raise DescriptorError(
         status_code=401,
         code="UNAUTHORIZED",


### PR DESCRIPTION
## Summary
- `app/auth.py`에 structlog 적용: 인증 성공/실패/JWT 무효 이벤트 로깅
- `app/api/routes.py`에 structlog 적용: 배치 완료 통계, description 미발견 로깅
- 기존 모듈(geocoder, landcover, describer, context, mission, composer, supabase)은 이미 structlog 적용 완료 상태

closes #79

## Test plan
- [x] 기존 185개 테스트 모두 통과 확인
- [ ] CI 파이프라인 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)