### PR TITLE
chore: bump version to 0.12.0 for Sprint 14 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-descriptor"
-version = "0.11.1"
+version = "0.12.0"
 description = "Image Descriptor Service for COGnito - generates rich descriptions for satellite imagery"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- Sprint 14 릴리스를 위한 버전 범프 (0.11.1 → 0.12.0)

## Sprint 14 변경사항
- **#86**: `auth.py`, `api/routes.py`에 structlog 구조화 로깅 적용
- **#87**: `tests/test_config.py` Settings 검증 테스트 14개 추가
- **#88**: `tests/test_supabase.py` Supabase 클라이언트 테스트 10개 추가

## Test plan
- [x] 전체 테스트 195 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)