### PR TITLE
fix: read FastAPI version dynamically from package metadata

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 from contextlib import asynccontextmanager
+from importlib.metadata import PackageNotFoundError, version
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -26,9 +27,14 @@ async def lifespan(app: FastAPI):
     await app.state.cache.close()
 
 
+try:
+    _app_version = version("cognito-descriptor")
+except PackageNotFoundError:
+    _app_version = "unknown"
+
 app = FastAPI(
     title="COGnito Image Descriptor",
-    version="0.6.0",
+    version=_app_version,
     description=(
         "위성영상 분석 API - 좌표 기반 역지오코딩, 토지피복 분류, "
         "Gemini AI 영상 설명, 맥락 정보를 통합 제공합니다."

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -3,7 +3,7 @@
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from app.main import app
+from app.main import app, _app_version
 
 
 @pytest.fixture
@@ -28,7 +28,7 @@ def test_app_title(openapi_schema):
 
 
 def test_app_version(openapi_schema):
-    assert openapi_schema["info"]["version"] == "0.6.0"
+    assert openapi_schema["info"]["version"] == _app_version
 
 
 def test_app_description(openapi_schema):


### PR DESCRIPTION
## Summary
- `app/main.py`의 하드코딩된 `version="0.6.0"`을 `importlib.metadata.version("cognito-descriptor")`로 교체
- OpenAPI docs 버전이 `pyproject.toml`과 자동 동기화됨
- 테스트도 동적 버전을 참조하도록 수정

## Test plan
- [x] `tests/test_openapi.py` 전체 통과 확인 (27 passed)

closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)