### PR TITLE
feat: add dependency health checks to /api/health endpoint

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -3,6 +3,7 @@ from importlib.metadata import PackageNotFoundError, version
 
 import structlog
 from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
 from slowapi import Limiter
 
 from app.api.schemas import (
@@ -60,14 +61,36 @@ async def cache_stats(request: Request):
     "/health",
     tags=["system"],
     summary="헬스체크",
-    description="서비스 상태와 버전 정보를 반환합니다.",
+    description="서비스 상태와 버전 정보, 의존성 상태를 반환합니다.",
 )
-async def health():
+async def health(request: Request):
     try:
         ver = version("cognito-descriptor")
     except PackageNotFoundError:
         ver = "unknown"
-    return {"status": "ok", "version": ver}
+
+    cache = request.app.state.cache
+    cache_ok = await cache.ping()
+    supabase_ok = await db.ping()
+
+    checks = {
+        "supabase": "ok" if supabase_ok else "fail",
+        "cache": "ok" if cache_ok else "fail",
+    }
+
+    all_fail = not supabase_ok and not cache_ok
+    any_fail = not supabase_ok or not cache_ok
+
+    if all_fail:
+        status = "unhealthy"
+    elif any_fail:
+        status = "degraded"
+    else:
+        status = "ok"
+
+    body = {"status": status, "version": ver, "checks": checks}
+    status_code = 503 if all_fail else 200
+    return JSONResponse(content=body, status_code=status_code)
 
 
 @router.post(

--- a/app/cache/store.py
+++ b/app/cache/store.py
@@ -84,6 +84,14 @@ class CacheStore:
             "modules": per_module,
         }
 
+    async def ping(self) -> bool:
+        try:
+            async with self._db.execute("SELECT 1") as cursor:
+                await cursor.fetchone()
+            return True
+        except Exception:
+            return False
+
     async def close(self):
         if self._db:
             await self._db.close()

--- a/app/db/supabase.py
+++ b/app/db/supabase.py
@@ -61,6 +61,16 @@ async def save_description(
         return None
 
 
+async def ping() -> bool:
+    try:
+        client = await get_client()
+        await client.table("image_descriptions").select("cog_image_id").limit(1).execute()
+        return True
+    except Exception as e:
+        logger.warning("supabase ping failed", error=str(e))
+        return False
+
+
 async def get_description(cog_image_id: str) -> dict | None:
     try:
         client = await get_client()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,12 +29,21 @@ async def client_with_cache(tmp_path):
     await cache.close()
 
 
-async def test_health(client):
-    resp = await client.get("/api/health")
+async def test_health(client_with_cache):
+    with pytest.MonkeyPatch.context() as mp:
+        import app.db.supabase as supabase_mod
+
+        async def _mock_ping():
+            return True
+
+        mp.setattr(supabase_mod, "ping", _mock_ping)
+        resp = await client_with_cache.get("/api/health")
     assert resp.status_code == 200
     data = resp.json()
     assert data["status"] == "ok"
     assert "version" in data
+    assert data["checks"]["cache"] == "ok"
+    assert data["checks"]["supabase"] == "ok"
 
 
 async def test_describe_no_api_key(client):
@@ -203,21 +212,39 @@ async def test_rate_limit_returns_429(tmp_path):
         await cache.close()
 
 
-async def test_health_no_rate_limit(client):
+async def test_health_no_rate_limit(client_with_cache, monkeypatch):
     """Health endpoint should not be rate limited."""
+    import app.db.supabase as supabase_mod
+
+    async def _mock_ping():
+        return True
+
+    monkeypatch.setattr(supabase_mod, "ping", _mock_ping)
     for _ in range(5):
-        resp = await client.get("/api/health")
+        resp = await client_with_cache.get("/api/health")
         assert resp.status_code == 200
 
 
-async def test_request_id_header(client):
-    resp = await client.get("/api/health")
+async def test_request_id_header(client_with_cache, monkeypatch):
+    import app.db.supabase as supabase_mod
+
+    async def _mock_ping():
+        return True
+
+    monkeypatch.setattr(supabase_mod, "ping", _mock_ping)
+    resp = await client_with_cache.get("/api/health")
     assert resp.status_code == 200
     assert "x-request-id" in resp.headers
     assert len(resp.headers["x-request-id"]) == 16
 
 
-async def test_request_id_passthrough(client):
+async def test_request_id_passthrough(client_with_cache, monkeypatch):
+    import app.db.supabase as supabase_mod
+
+    async def _mock_ping():
+        return True
+
+    monkeypatch.setattr(supabase_mod, "ping", _mock_ping)
     custom_id = "my-custom-request-id"
-    resp = await client.get("/api/health", headers={"X-Request-ID": custom_id})
+    resp = await client_with_cache.get("/api/health", headers={"X-Request-ID": custom_id})
     assert resp.headers["x-request-id"] == custom_id

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,109 @@
+"""Health endpoint dependency check tests for #91."""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.cache.store import CacheStore
+from app.main import app
+import app.db.supabase as supabase_mod
+
+
+@pytest.fixture
+async def health_client(tmp_path, monkeypatch):
+    cache = CacheStore(str(tmp_path / "test.db"))
+    await cache.init()
+    app.state.cache = cache
+
+    async def _supabase_ok():
+        return True
+
+    monkeypatch.setattr(supabase_mod, "ping", _supabase_ok)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as c:
+        yield c
+    await cache.close()
+
+
+async def test_health_all_ok(health_client):
+    resp = await health_client.get("/api/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert data["checks"]["supabase"] == "ok"
+    assert data["checks"]["cache"] == "ok"
+    assert "version" in data
+
+
+async def test_health_supabase_fail(tmp_path, monkeypatch):
+    cache = CacheStore(str(tmp_path / "test.db"))
+    await cache.init()
+    app.state.cache = cache
+
+    async def _supabase_fail():
+        return False
+
+    monkeypatch.setattr(supabase_mod, "ping", _supabase_fail)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as c:
+        resp = await c.get("/api/health")
+    await cache.close()
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "degraded"
+    assert data["checks"]["supabase"] == "fail"
+    assert data["checks"]["cache"] == "ok"
+
+
+async def test_health_cache_fail(tmp_path, monkeypatch):
+    cache = CacheStore(str(tmp_path / "test.db"))
+    await cache.init()
+    await cache.close()  # close to make ping fail
+    app.state.cache = cache
+
+    async def _supabase_ok():
+        return True
+
+    monkeypatch.setattr(supabase_mod, "ping", _supabase_ok)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as c:
+        resp = await c.get("/api/health")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "degraded"
+    assert data["checks"]["cache"] == "fail"
+    assert data["checks"]["supabase"] == "ok"
+
+
+async def test_health_all_fail(tmp_path, monkeypatch):
+    cache = CacheStore(str(tmp_path / "test.db"))
+    await cache.init()
+    await cache.close()  # close to make ping fail
+    app.state.cache = cache
+
+    async def _supabase_fail():
+        return False
+
+    monkeypatch.setattr(supabase_mod, "ping", _supabase_fail)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as c:
+        resp = await c.get("/api/health")
+
+    assert resp.status_code == 503
+    data = resp.json()
+    assert data["status"] == "unhealthy"
+    assert data["checks"]["supabase"] == "fail"
+    assert data["checks"]["cache"] == "fail"


### PR DESCRIPTION
## Summary
- Supabase, SQLite 캐시의 연결 상태를 `/api/health`에서 확인
- 모든 의존성 정상: `"status": "ok"` (200)
- 일부 실패: `"status": "degraded"` (200)
- 전체 실패: `"status": "unhealthy"` (503)
- `checks` 필드에 개별 의존성 상태 포함

## Test plan
- [x] `test_health_all_ok` - 모든 의존성 정상
- [x] `test_health_supabase_fail` - Supabase만 실패 → degraded
- [x] `test_health_cache_fail` - 캐시만 실패 → degraded
- [x] `test_health_all_fail` - 전체 실패 → unhealthy (503)
- [x] 전체 테스트 213건 통과

closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)