### PR TITLE
chore: bump version to 0.12.0 for Sprint 15 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-descriptor"
-version = "0.11.1"
+version = "0.12.0"
 description = "Image Descriptor Service for COGnito - generates rich descriptions for satellite imagery"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- Version bump `0.11.1` → `0.12.0` for Sprint 15 release
- Includes Sprint 14-15 changes:
  - **#86** feat: add structlog to auth and API routes
  - **#87** test: add Settings validation tests
  - **#88** test: add Supabase client init and error handling tests
  - **#93** fix: read FastAPI version dynamically from package metadata
  - **#94** feat: add dependency health checks to /api/health endpoint

## Test plan
- [x] All 213 tests pass, 3 skipped (e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)