### PR TITLE
feat: add automatic cleanup of expired SQLite cache entries

### DIFF
--- a/app/cache/store.py
+++ b/app/cache/store.py
@@ -3,8 +3,11 @@ import time
 from collections import defaultdict
 
 import aiosqlite
+import structlog
 
-from app.utils.metrics import cache_hits, cache_misses
+from app.utils.metrics import cache_cleanup_total, cache_hits, cache_misses
+
+logger = structlog.get_logger()
 
 
 class CacheStore:
@@ -91,6 +94,18 @@ class CacheStore:
             return True
         except Exception:
             return False
+
+    async def cleanup_expired(self) -> int:
+        now = time.time()
+        async with self._db.execute(
+            "DELETE FROM cache WHERE expires_at IS NOT NULL AND expires_at < ?", (now,)
+        ) as cursor:
+            deleted = cursor.rowcount
+        await self._db.commit()
+        if deleted > 0:
+            cache_cleanup_total.inc(deleted)
+            logger.info("cache_cleanup", deleted=deleted)
+        return deleted
 
     async def close(self):
         if self._db:

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import asynccontextmanager
 from importlib.metadata import PackageNotFoundError, version
 
@@ -16,14 +17,31 @@ from app.utils.rate_limit import get_real_ip
 
 setup_logging()
 
+CACHE_CLEANUP_INTERVAL_SECONDS = 3600
+
 limiter = Limiter(key_func=get_real_ip)
+
+
+async def _cache_cleanup_loop(cache: CacheStore):
+    while True:
+        await asyncio.sleep(CACHE_CLEANUP_INTERVAL_SECONDS)
+        try:
+            await cache.cleanup_expired()
+        except Exception:
+            pass
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     app.state.cache = CacheStore(settings.cache_db_path)
     await app.state.cache.init()
+    cleanup_task = asyncio.create_task(_cache_cleanup_loop(app.state.cache))
     yield
+    cleanup_task.cancel()
+    try:
+        await cleanup_task
+    except asyncio.CancelledError:
+        pass
     await app.state.cache.close()
 
 

--- a/app/utils/metrics.py
+++ b/app/utils/metrics.py
@@ -28,6 +28,11 @@ cache_misses = Counter(
     ["module"],
 )
 
+cache_cleanup_total = Counter(
+    "cache_cleanup_total",
+    "Total expired cache entries removed",
+)
+
 # Circuit breaker metrics
 circuit_breaker_state = Gauge(
     "circuit_breaker_open",

--- a/tests/test_cache_cleanup.py
+++ b/tests/test_cache_cleanup.py
@@ -1,0 +1,53 @@
+import time
+
+import pytest
+
+from app.cache.store import CacheStore
+
+
+@pytest.fixture
+async def cache(tmp_path):
+    store = CacheStore(str(tmp_path / "test.db"))
+    await store.init()
+    yield store
+    await store.close()
+
+
+class TestCleanupExpired:
+    async def test_removes_expired_entries(self, cache):
+        await cache.set("geo:expired1", {"v": 1}, ttl_days=0)
+        await cache._db.execute(
+            "UPDATE cache SET expires_at = ? WHERE key = ?",
+            (time.time() - 100, "geo:expired1"),
+        )
+        await cache._db.commit()
+        await cache.set("geo:valid", {"v": 2}, ttl_days=30)
+
+        deleted = await cache.cleanup_expired()
+        assert deleted == 1
+
+        assert await cache.get("geo:expired1") is None
+        assert await cache.get("geo:valid") == {"v": 2}
+
+    async def test_no_expired_entries(self, cache):
+        await cache.set("geo:valid", {"v": 1}, ttl_days=30)
+        deleted = await cache.cleanup_expired()
+        assert deleted == 0
+
+    async def test_entries_without_expiry_not_removed(self, cache):
+        await cache.set("geo:permanent", {"v": 1})
+        deleted = await cache.cleanup_expired()
+        assert deleted == 0
+        assert await cache.get("geo:permanent") == {"v": 1}
+
+    async def test_multiple_expired_entries(self, cache):
+        for i in range(5):
+            await cache.set(f"geo:expired{i}", {"v": i}, ttl_days=0)
+            await cache._db.execute(
+                "UPDATE cache SET expires_at = ? WHERE key = ?",
+                (time.time() - 100, f"geo:expired{i}"),
+            )
+        await cache._db.commit()
+
+        deleted = await cache.cleanup_expired()
+        assert deleted == 5


### PR DESCRIPTION
## Summary
- `CacheStore.cleanup_expired()` 메서드 추가 — `expires_at < now`인 항목 일괄 삭제
- FastAPI lifespan에서 1시간 간격 백그라운드 cleanup 태스크 실행
- `cache_cleanup_total` Prometheus counter 메트릭 추가

## Test plan
- [x] 만료 항목 삭제 검증
- [x] 만료 항목 없을 때 0 반환
- [x] `expires_at`이 NULL인 영구 항목 미삭제 확인
- [x] 다수 만료 항목 일괄 삭제
- [x] 전체 테스트 217개 통과

closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)