### PR TITLE
feat: API 응답 캐시 헤더 및 ETag 지원

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,8 +1,9 @@
 import asyncio
+import hashlib
 from importlib.metadata import PackageNotFoundError, version
 
 import structlog
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Header, Request
 from fastapi.responses import JSONResponse
 from slowapi import Limiter
 
@@ -99,6 +100,10 @@ async def health(request: Request):
     return JSONResponse(content=body, status_code=status_code)
 
 
+def _generate_etag(body_bytes: bytes) -> str:
+    return f'"{hashlib.md5(body_bytes).hexdigest()}"'  # noqa: S324
+
+
 @router.post(
     "/describe",
     response_model=DescribeResponse,
@@ -109,6 +114,7 @@ async def health(request: Request):
         "Gemini AI 영상 설명, 맥락 정보를 통합 생성합니다."
     ),
     responses={
+        304: {"description": "캐시 유효 (Not Modified)"},
         422: {
             "model": ErrorResponse,
             "description": "유효하지 않은 요청 (좌표 범위 초과, 썸네일 과대 등)",
@@ -121,9 +127,22 @@ async def describe(
     body: DescribeRequest,
     request: Request,
     _auth: dict = Depends(authenticate),
+    if_none_match: str | None = Header(None),
 ):
     cache = request.app.state.cache
-    return await _describe_and_save(body, cache)
+    result = await _describe_and_save(body, cache)
+
+    body_bytes = result.model_dump_json().encode()
+    etag = _generate_etag(body_bytes)
+
+    if if_none_match and if_none_match == etag:
+        return JSONResponse(status_code=304, content=None, headers={"ETag": etag})
+
+    cache_control = "private, max-age=3600" if result.cached else "no-cache"
+    return JSONResponse(
+        content=result.model_dump(mode="json"),
+        headers={"ETag": etag, "Cache-Control": cache_control},
+    )
 
 
 @router.post(

--- a/app/modules/describer.py
+++ b/app/modules/describer.py
@@ -137,13 +137,13 @@ async def describe_image(
     cache: CacheStore,
     cog_image_id: str | None = None,
     bbox: list[float] | None = None,
-) -> str:
+) -> tuple[str, bool]:
     if cog_image_id:
         cache_key = f"describe:{cog_image_id}"
         cached = await cache.get(cache_key)
         if cached:
             logger.debug("describer cache hit", cog_image_id=cog_image_id)
-            return cached["description"]
+            return cached["description"], True
 
     # 썸네일 데이터 준비
     if thumbnail.startswith("data:image"):
@@ -168,4 +168,4 @@ async def describe_image(
         await cache.set(f"describe:{cog_image_id}", {"description": description})
 
     logger.info("describer result", description_length=len(description))
-    return description
+    return description, False

--- a/app/services/composer.py
+++ b/app/services/composer.py
@@ -97,8 +97,13 @@ async def compose_description(request: DescribeRequest, cache: CacheStore) -> De
             warnings,
         )
     )
-    description, context_result = await asyncio.gather(desc_task, ctx_task)
+    desc_result, context_result = await asyncio.gather(desc_task, ctx_task)
     logger.info("phase2_complete", duration_ms=round((time.monotonic() - t_phase2) * 1000))
+
+    if desc_result is not None:
+        description, cached = desc_result
+    else:
+        description, cached = None, False
 
     total_ms = round((time.monotonic() - t_start) * 1000)
     logger.info("compose_complete", total_duration_ms=total_ms, warning_count=len(warnings))
@@ -110,5 +115,5 @@ async def compose_description(request: DescribeRequest, cache: CacheStore) -> De
         context=context_result,
         mission=mission_result,
         warnings=warnings,
-        cached=False,
+        cached=cached,
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -323,3 +323,71 @@ class TestDescribeAndSave:
 
         mock_save.assert_not_awaited()
         assert result.saved is None
+
+
+class TestDescribeCacheHeaders:
+    @pytest.fixture
+    async def _mock_describe(self, client_with_cache, monkeypatch):
+        from unittest.mock import AsyncMock
+
+        from app.api.schemas import DescribeResponse
+
+        mock_result = DescribeResponse(description="test desc", cached=False)
+        monkeypatch.setattr(
+            "app.api.routes._describe_and_save",
+            AsyncMock(return_value=mock_result),
+        )
+        return client_with_cache, mock_result
+
+    async def test_describe_returns_etag_header(self, _mock_describe):
+        client, _ = _mock_describe
+        resp = await client.post(
+            "/api/describe",
+            json={"thumbnail": "dGVzdA==", "coordinates": [126.978, 37.566]},
+            headers={"X-API-Key": os.environ["API_KEY"]},
+        )
+        assert resp.status_code == 200
+        assert "etag" in resp.headers
+        assert resp.headers["cache-control"] == "no-cache"
+
+    async def test_describe_cached_returns_max_age(self, client_with_cache, monkeypatch):
+        from unittest.mock import AsyncMock
+
+        from app.api.schemas import DescribeResponse
+
+        mock_result = DescribeResponse(description="cached desc", cached=True)
+        monkeypatch.setattr(
+            "app.api.routes._describe_and_save",
+            AsyncMock(return_value=mock_result),
+        )
+        resp = await client_with_cache.post(
+            "/api/describe",
+            json={"thumbnail": "dGVzdA==", "coordinates": [126.978, 37.566]},
+            headers={"X-API-Key": os.environ["API_KEY"]},
+        )
+        assert resp.status_code == 200
+        assert resp.headers["cache-control"] == "private, max-age=3600"
+
+    async def test_describe_304_with_matching_etag(self, _mock_describe):
+        client, _ = _mock_describe
+        body = {"thumbnail": "dGVzdA==", "coordinates": [126.978, 37.566]}
+        headers = {"X-API-Key": os.environ["API_KEY"]}
+
+        resp1 = await client.post("/api/describe", json=body, headers=headers)
+        etag = resp1.headers["etag"]
+
+        headers["If-None-Match"] = etag
+        resp2 = await client.post("/api/describe", json=body, headers=headers)
+        assert resp2.status_code == 304
+
+    async def test_describe_200_with_mismatched_etag(self, _mock_describe):
+        client, _ = _mock_describe
+        resp = await client.post(
+            "/api/describe",
+            json={"thumbnail": "dGVzdA==", "coordinates": [126.978, 37.566]},
+            headers={
+                "X-API-Key": os.environ["API_KEY"],
+                "If-None-Match": '"wrong-etag"',
+            },
+        )
+        assert resp.status_code == 200

--- a/tests/test_composer.py
+++ b/tests/test_composer.py
@@ -46,7 +46,7 @@ async def test_compose_all_success(mock_geo, mock_lc, mock_desc, mock_ctx, cache
             summary="주거지역 60%",
         )
     )
-    mock_desc.describe_image = AsyncMock(return_value="위성영상 설명입니다.")
+    mock_desc.describe_image = AsyncMock(return_value=("위성영상 설명입니다.", False))
     mock_ctx.research_context = AsyncMock(
         return_value=Context(
             events=[
@@ -83,7 +83,7 @@ async def test_compose_partial_failure(mock_geo, mock_lc, mock_desc, mock_ctx, c
             summary="정보 없음",
         )
     )
-    mock_desc.describe_image = AsyncMock(return_value="설명 텍스트")
+    mock_desc.describe_image = AsyncMock(return_value=("설명 텍스트", False))
     mock_ctx.research_context = AsyncMock(return_value=Context(events=[], summary="없음"))
 
     result = await compose_description(_make_request(), cache)
@@ -158,7 +158,7 @@ async def test_compose_landcover_fail_geocoder_ok(mock_geo, mock_lc, mock_desc, 
         )
     )
     mock_lc.get_land_cover = AsyncMock(side_effect=Exception("LandCover API error"))
-    mock_desc.describe_image = AsyncMock(return_value="설명 텍스트")
+    mock_desc.describe_image = AsyncMock(return_value=("설명 텍스트", False))
     mock_ctx.research_context = AsyncMock(return_value=Context(events=[], summary="없음"))
 
     result = await compose_description(_make_request(), cache)
@@ -181,7 +181,7 @@ async def test_compose_phase1_both_fail_phase2_uses_fallback(
     """Phase 1 양쪽 실패 시 Phase 2가 fallback 값으로 동작하는지 검증."""
     mock_geo.geocode = AsyncMock(side_effect=Exception("fail"))
     mock_lc.get_land_cover = AsyncMock(side_effect=Exception("fail"))
-    mock_desc.describe_image = AsyncMock(return_value="fallback 설명")
+    mock_desc.describe_image = AsyncMock(return_value=("fallback 설명", False))
     mock_ctx.research_context = AsyncMock(return_value=Context(events=[], summary="없음"))
 
     result = await compose_description(_make_request(), cache)
@@ -255,7 +255,7 @@ async def test_compose_without_captured_at(mock_geo, mock_lc, mock_desc, mock_ct
         )
     )
     mock_lc.get_land_cover = AsyncMock(return_value=LandCover(classes=[], summary="정보 없음"))
-    mock_desc.describe_image = AsyncMock(return_value="설명")
+    mock_desc.describe_image = AsyncMock(return_value=("설명", False))
     mock_ctx.research_context = AsyncMock(return_value=Context(events=[], summary="없음"))
 
     result = await compose_description(request, cache)
@@ -290,7 +290,7 @@ async def test_compose_without_bbox(mock_geo, mock_lc, mock_desc, mock_ctx, cach
         )
     )
     mock_lc.get_land_cover = AsyncMock(return_value=LandCover(classes=[], summary="정보 없음"))
-    mock_desc.describe_image = AsyncMock(return_value="설명")
+    mock_desc.describe_image = AsyncMock(return_value=("설명", False))
     mock_ctx.research_context = AsyncMock(return_value=Context(events=[], summary="없음"))
 
     result = await compose_description(request, cache)
@@ -323,7 +323,7 @@ async def test_compose_polar_coordinates(mock_geo, mock_lc, mock_desc, mock_ctx,
         )
     )
     mock_lc.get_land_cover = AsyncMock(return_value=LandCover(classes=[], summary="빙하"))
-    mock_desc.describe_image = AsyncMock(return_value="극지 설명")
+    mock_desc.describe_image = AsyncMock(return_value=("극지 설명", False))
     mock_ctx.research_context = AsyncMock(return_value=Context(events=[], summary="없음"))
 
     result = await compose_description(request, cache)
@@ -355,7 +355,7 @@ async def test_compose_dateline_coordinates(mock_geo, mock_lc, mock_desc, mock_c
         )
     )
     mock_lc.get_land_cover = AsyncMock(return_value=LandCover(classes=[], summary="해양"))
-    mock_desc.describe_image = AsyncMock(return_value="태평양 설명")
+    mock_desc.describe_image = AsyncMock(return_value=("태평양 설명", False))
     mock_ctx.research_context = AsyncMock(return_value=Context(events=[], summary="없음"))
 
     result = await compose_description(request, cache)
@@ -424,7 +424,7 @@ async def test_compose_timing_logs_emitted(mock_geo, mock_lc, mock_desc, mock_ct
         )
     )
     mock_lc.get_land_cover = AsyncMock(return_value=LandCover(classes=[], summary="정보 없음"))
-    mock_desc.describe_image = AsyncMock(return_value="설명")
+    mock_desc.describe_image = AsyncMock(return_value=("설명", False))
     mock_ctx.research_context = AsyncMock(return_value=Context(events=[], summary="없음"))
 
     with structlog.testing.capture_logs() as logs:

--- a/tests/test_describer.py
+++ b/tests/test_describer.py
@@ -50,7 +50,9 @@ async def test_describe_image(mock_genai, _mock_resize, cache):
     thumbnail = base64.b64encode(b"fake-image-data").decode()
     result = await describe_image(thumbnail, "서울특별시", "2025-06-15", "주거지역 50%", cache)
 
-    assert result == "서울 도심의 위성영상입니다."
+    description, cached = result
+    assert description == "서울 도심의 위성영상입니다."
+    assert cached is False
     mock_client.models.generate_content.assert_called_once()
 
 
@@ -63,7 +65,9 @@ async def test_describe_image_cache_hit(mock_genai, cache):
         "dGVzdA==", "서울", "2025-06-15", "summary", cache, cog_image_id="test-id"
     )
 
-    assert result == "cached description"
+    description, cached = result
+    assert description == "cached description"
+    assert cached is True
     mock_genai.Client.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- `/describe` 엔드포인트에 ETag, Cache-Control 헤더 추가
- `If-None-Match` 요청 헤더 지원으로 304 Not Modified 반환
- 캐시 히트 시 `Cache-Control: private, max-age=3600`, 캐시 미스 시 `no-cache`

## Test plan
- [x] ETag 헤더 반환 확인
- [x] 캐시 히트 시 max-age 설정 확인
- [x] If-None-Match 매칭 시 304 반환
- [x] If-None-Match 불일치 시 200 반환
- [x] 전체 테스트 스위트 통과 (225 passed)

closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)