### PR TITLE
chore: bump version to 0.14.0 for Sprint 18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-descriptor"
-version = "0.12.0"
+version = "0.14.0"
 description = "Image Descriptor Service for COGnito - generates rich descriptions for satellite imagery"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- 스프린트 18 릴리스를 위한 버전 0.14.0 범프

🤖 Generated with [Claude Code](https://claude.com/claude-code)