### PR TITLE
chore: bump version to 0.15.0 for Sprint 19 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-descriptor"
-version = "0.14.0"
+version = "0.15.0"
 description = "Image Descriptor Service for COGnito - generates rich descriptions for satellite imagery"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- Version bump from 0.14.0 to 0.15.0 for Sprint 19 release
- Includes: X-Request-ID validation (#107), cache header integration tests (#109), 304 empty body fix (RFC 7232)

🤖 Generated with [Claude Code](https://claude.com/claude-code)