### PR TITLE
chore: bump version to 0.16.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-descriptor"
-version = "0.15.0"
+version = "0.16.0"
 description = "Image Descriptor Service for COGnito - generates rich descriptions for satellite imagery"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- Sprint 20 릴리스를 위한 버전 범프 (0.15.0 → 0.16.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)