### PR TITLE
feat: circuit breaker 상태 조회 엔드포인트 추가

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -12,6 +12,7 @@ from app.api.schemas import (
     BatchDescribeRequest,
     BatchDescribeResponse,
     BatchItemResult,
+    CircuitBreakerResponse,
     Context,
     DescribeRequest,
     DescribeResponse,
@@ -23,7 +24,7 @@ from app.api.schemas import (
 from app.auth import authenticate
 from app.config import settings
 from app.db import supabase as db
-from app.services.composer import compose_description
+from app.services.composer import compose_description, get_breaker_statuses
 from app.utils.errors import DescriptorError
 from app.utils.rate_limit import get_real_ip
 from app.utils.timeout import apply_timeout
@@ -63,6 +64,17 @@ async def _describe_and_save(item: DescribeRequest, cache) -> DescribeResponse:
 async def cache_stats(request: Request):
     cache = request.app.state.cache
     return await cache.stats()
+
+
+@router.get(
+    "/circuits",
+    response_model=CircuitBreakerResponse,
+    tags=["system"],
+    summary="Circuit breaker 상태 조회",
+    description="각 외부 서비스의 circuit breaker 상태(open/closed, 실패 횟수, cooldown 잔여 시간)를 반환합니다.",
+)
+async def circuit_breaker_status():
+    return CircuitBreakerResponse(breakers=get_breaker_statuses())
 
 
 @router.get(

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -219,6 +219,47 @@ class BatchDescribeResponse(BaseModel):
     failed: int
 
 
+class CircuitBreakerStatus(BaseModel):
+    name: str = Field(description="서비스 이름")
+    state: str = Field(description="Circuit breaker 상태 (closed/open)")
+    failure_count: int = Field(description="현재 연속 실패 횟수")
+    cooldown_remaining: float = Field(description="Open 상태 시 남은 cooldown 시간(초)")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "name": "geocoder",
+                    "state": "closed",
+                    "failure_count": 0,
+                    "cooldown_remaining": 0.0,
+                }
+            ]
+        }
+    }
+
+
+class CircuitBreakerResponse(BaseModel):
+    breakers: list[CircuitBreakerStatus]
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "breakers": [
+                        {
+                            "name": "geocoder",
+                            "state": "closed",
+                            "failure_count": 0,
+                            "cooldown_remaining": 0.0,
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+
+
 class ErrorResponse(BaseModel):
     """API 에러 응답 모델"""
 

--- a/app/services/composer.py
+++ b/app/services/composer.py
@@ -22,6 +22,10 @@ _breakers = {
 }
 
 
+def get_breaker_statuses() -> list[dict]:
+    return [cb.get_status() for cb in _breakers.values()]
+
+
 async def _safe_call(name: str, coro: Awaitable, warnings: list[Warning]):
     cb = _breakers[name]
     if cb.is_open:

--- a/app/utils/circuit_breaker.py
+++ b/app/utils/circuit_breaker.py
@@ -32,6 +32,16 @@ class CircuitBreaker:
         self._open_until = 0.0
         circuit_breaker_state.labels(name=self.name).set(0)
 
+    def get_status(self) -> dict:
+        is_open = self.is_open
+        cooldown_remaining = max(0.0, self._open_until - time.time()) if is_open else 0.0
+        return {
+            "name": self.name,
+            "state": "open" if is_open else "closed",
+            "failure_count": self._failure_count,
+            "cooldown_remaining": round(cooldown_remaining, 1),
+        }
+
     def record_failure(self):
         self._failure_count += 1
         if self._failure_count >= self.failure_threshold:

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -1,0 +1,72 @@
+import time
+from unittest.mock import patch
+
+import pytest
+
+from app.utils.circuit_breaker import CircuitBreaker
+
+
+class TestCircuitBreakerGetStatus:
+    def test_closed_status(self):
+        cb = CircuitBreaker("geocoder")
+        status = cb.get_status()
+        assert status["name"] == "geocoder"
+        assert status["state"] == "closed"
+        assert status["failure_count"] == 0
+        assert status["cooldown_remaining"] == 0.0
+
+    def test_open_status(self):
+        cb = CircuitBreaker("geocoder", failure_threshold=2, cooldown_sec=30.0)
+        cb.record_failure()
+        cb.record_failure()
+        status = cb.get_status()
+        assert status["state"] == "open"
+        assert status["failure_count"] == 2
+        assert status["cooldown_remaining"] > 0
+
+    def test_cooldown_remaining_decreases(self):
+        cb = CircuitBreaker("geocoder", failure_threshold=1, cooldown_sec=10.0)
+        cb.record_failure()
+        with patch("app.utils.circuit_breaker.time") as mock_time:
+            mock_time.time.return_value = time.time() + 5
+            status = cb.get_status()
+            assert status["cooldown_remaining"] <= 5.1
+
+
+class TestCircuitsEndpoint:
+    @pytest.fixture
+    async def client(self, tmp_path):
+        from httpx import ASGITransport, AsyncClient
+
+        from app.cache.store import CacheStore
+        from app.main import app
+
+        store = CacheStore(str(tmp_path / "cache.db"))
+        await store.init()
+        app.state.cache = store
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as c:
+            yield c
+        await store.close()
+
+    async def test_endpoint_returns_200(self, client):
+        resp = await client.get("/api/circuits")
+        assert resp.status_code == 200
+
+    async def test_response_structure(self, client):
+        resp = await client.get("/api/circuits")
+        data = resp.json()
+        assert "breakers" in data
+        assert len(data["breakers"]) == 5
+        for breaker in data["breakers"]:
+            assert "name" in breaker
+            assert "state" in breaker
+            assert "failure_count" in breaker
+            assert "cooldown_remaining" in breaker
+
+    async def test_all_services_present(self, client):
+        resp = await client.get("/api/circuits")
+        names = {b["name"] for b in resp.json()["breakers"]}
+        assert names == {"geocoder", "landcover", "describer", "context", "mission"}


### PR DESCRIPTION
## Summary
- `GET /api/circuits` 엔드포인트 추가 — 각 외부 서비스의 circuit breaker 상태(open/closed, failure_count, cooldown_remaining)를 JSON으로 반환
- `CircuitBreaker.get_status()` 메서드 및 `CircuitBreakerStatus`/`CircuitBreakerResponse` 스키마 정의
- 단위 테스트 6개 추가 (모두 통과)

closes #116

## Test plan
- [x] `pytest tests/test_circuits.py` — 6 passed
- [x] `pytest tests/` — 247 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)