### PR TITLE
chore: bump version to 0.17.0 for Sprint 21 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-descriptor"
-version = "0.16.0"
+version = "0.17.0"
 description = "Image Descriptor Service for COGnito - generates rich descriptions for satellite imagery"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- `pyproject.toml` 버전을 0.16.0 → 0.17.0으로 업데이트

## Sprint 21 포함 내용
- feat: circuit breaker 상태 조회 엔드포인트 (#116, #119)
- refactor: structlog key-value 로깅 (#117, #120)

🤖 Generated with [Claude Code](https://claude.com/claude-code)