### PR TITLE
refactor: /health 및 /cache/stats에 response_model 스키마 추가

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -12,11 +12,13 @@ from app.api.schemas import (
     BatchDescribeRequest,
     BatchDescribeResponse,
     BatchItemResult,
+    CacheStatsResponse,
     CircuitBreakerResponse,
     Context,
     DescribeRequest,
     DescribeResponse,
     ErrorResponse,
+    HealthResponse,
     LandCover,
     Location,
     Warning,
@@ -57,6 +59,7 @@ async def _describe_and_save(item: DescribeRequest, cache) -> DescribeResponse:
 
 @router.get(
     "/cache/stats",
+    response_model=CacheStatsResponse,
     tags=["system"],
     summary="캐시 통계 조회",
     description="SQLite 캐시의 히트/미스 통계 및 항목 수를 반환합니다.",
@@ -79,9 +82,16 @@ async def circuit_breaker_status():
 
 @router.get(
     "/health",
+    response_model=HealthResponse,
     tags=["system"],
     summary="헬스체크",
     description="서비스 상태와 버전 정보, 의존성 상태를 반환합니다.",
+    responses={
+        503: {
+            "model": HealthResponse,
+            "description": "서비스 비정상 (unhealthy 또는 shutting_down)",
+        },
+    },
 )
 async def health(request: Request):
     try:

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -260,6 +260,55 @@ class CircuitBreakerResponse(BaseModel):
     }
 
 
+class ModuleStats(BaseModel):
+    hits: int = Field(description="캐시 히트 횟수")
+    misses: int = Field(description="캐시 미스 횟수")
+    hit_rate: float = Field(description="히트율 (0.0 ~ 1.0)")
+
+
+class CacheStatsResponse(BaseModel):
+    entry_count: int = Field(description="캐시 항목 수")
+    total_bytes: int = Field(description="캐시 총 크기(바이트)")
+    modules: dict[str, ModuleStats] = Field(description="모듈별 캐시 통계")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "entry_count": 42,
+                    "total_bytes": 102400,
+                    "modules": {
+                        "geocode": {"hits": 10, "misses": 3, "hit_rate": 0.7692},
+                    },
+                }
+            ]
+        }
+    }
+
+
+class DependencyCheck(BaseModel):
+    supabase: str = Field(description="Supabase 연결 상태")
+    cache: str = Field(description="캐시 연결 상태")
+
+
+class HealthResponse(BaseModel):
+    status: str = Field(description="서비스 상태 (ok/degraded/unhealthy/shutting_down)")
+    version: str = Field(description="서비스 버전")
+    checks: DependencyCheck = Field(description="의존성 상태")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "status": "ok",
+                    "version": "0.16.0",
+                    "checks": {"supabase": "ok", "cache": "ok"},
+                }
+            ]
+        }
+    }
+
+
 class ErrorResponse(BaseModel):
     """API 에러 응답 모델"""
 


### PR DESCRIPTION
## Summary
- `HealthResponse`, `DependencyCheck`, `CacheStatsResponse`, `ModuleStats` Pydantic 스키마를 `schemas.py`에 추가
- `/api/health`, `/api/cache/stats` 엔드포인트에 `response_model` 지정하여 OpenAPI 문서에 응답 스키마 자동 반영
- `/health` 503 응답에도 `HealthResponse` 모델 문서화

closes #124

## Test plan
- [x] 기존 테스트 254건 모두 통과 확인
- [x] `test_health.py`, `test_cache_stats.py`, `test_openapi.py` 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)