### PR TITLE
docs: CHANGELOG 및 README 최신화 (v0.14.0~v0.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-03-06
+
+### Added
+
+- `GET /api/circuits`: Circuit breaker 상태 조회 엔드포인트 추가
+- `HealthResponse`, `DependencyCheck`, `CacheStatsResponse`, `ModuleStats` Pydantic 응답 스키마 추가
+- `/api/health`, `/api/cache/stats` 엔드포인트에 `response_model` 지정 (OpenAPI 문서 자동 반영)
+
+### Changed
+
+- structlog 로깅을 f-string에서 key-value 방식으로 전환
+
+### Fixed
+
+- CI lint 오류 수정 (ruff 규칙 위반)
+
+## [0.16.0] - 2026-03-06
+
+### Added
+
+- Graceful shutdown: SIGTERM 시그널 핸들러, in-flight request draining, `/health`에 `shutting_down` 상태 반영
+- Request timeout: `asyncio.wait_for` 기반 개별 요청 타임아웃 (기본 30초), 504 반환
+- Batch concurrency: `asyncio.Semaphore` 기반 배치 동시성 제한 (기본 3)
+- 신규 환경변수: `SHUTDOWN_TIMEOUT`, `REQUEST_TIMEOUT`, `BATCH_CONCURRENCY`
+
+## [0.15.0] - 2026-03-06
+
+### Added
+
+- `X-Request-ID` 헤더 유효성 검증
+- 캐시 응답 헤더 및 ETag 통합 테스트
+
+## [0.14.0] - 2026-03-06
+
+### Added
+
+- API 응답 캐시 헤더 및 ETag 지원
+- SSRF DNS rebinding 및 리다이렉트 보호 강화
+- SQLite 캐시 만료 항목 자동 정리
+
 ## [0.3.1] - 2026-02-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ uv run uvicorn app.main:app --reload
 | `CACHE_DB_PATH` | - | `./cache.db` | 캐시 DB 경로 |
 | `LOG_LEVEL` | - | `INFO` | 로그 레벨 |
 | `THUMBNAIL_MAX_PIXELS` | - | `768` | Gemini 전송 전 이미지 리사이즈 최대 픽셀 |
+| `SHUTDOWN_TIMEOUT` | - | `30` | Graceful shutdown 대기 시간(초) |
+| `REQUEST_TIMEOUT` | - | `30` | 개별 요청 타임아웃(초) |
+| `BATCH_CONCURRENCY` | - | `3` | 배치 동시 처리 수 |
 
 ## 인증
 
@@ -48,7 +51,11 @@ curl http://localhost:8000/api/health
 ```
 
 ```json
-{"status": "ok", "version": "0.2.0"}
+{
+  "status": "ok",
+  "version": "0.17.0",
+  "checks": {"supabase": "ok", "cache": "ok"}
+}
 ```
 
 ### `POST /api/describe`
@@ -74,7 +81,7 @@ curl -X POST http://localhost:8000/api/describe \
 |------|------|------|------|
 | `thumbnail` | string | O | base64 PNG 또는 이미지 URL |
 | `coordinates` | [float, float] | O | [경도, 위도] |
-| `captured_at` | string | O | 촬영일 (ISO 8601) |
+| `captured_at` | string | - | 촬영일 (ISO 8601) |
 | `bbox` | [float, float, float, float] | - | [west, south, east, north] |
 | `cog_image_id` | string | - | DB 연동용 cog_images UUID |
 
@@ -152,6 +159,70 @@ curl -X POST http://localhost:8000/api/context \
 ```
 
 **응답:** `Context` 객체
+
+### `POST /api/batch/describe`
+
+여러 이미지를 한 번에 분석한다. 최대 10건.
+
+```bash
+curl -X POST http://localhost:8000/api/batch/describe \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-api-key" \
+  -d '{
+    "items": [
+      {"thumbnail": "url-or-base64", "coordinates": [126.978, 37.566]},
+      {"thumbnail": "url-or-base64", "coordinates": [129.075, 35.179]}
+    ]
+  }'
+```
+
+**응답:**
+
+```json
+{
+  "results": [
+    {"index": 0, "result": {...}, "error": null},
+    {"index": 1, "result": null, "error": "오류 메시지"}
+  ],
+  "total": 2,
+  "succeeded": 1,
+  "failed": 1
+}
+```
+
+### `GET /api/circuits`
+
+Circuit breaker 상태를 조회한다.
+
+```bash
+curl -H "X-API-Key: your-api-key" http://localhost:8000/api/circuits
+```
+
+```json
+{
+  "breakers": [
+    {"name": "geocoder", "state": "closed", "failure_count": 0, "cooldown_remaining": 0.0}
+  ]
+}
+```
+
+### `GET /api/cache/stats`
+
+캐시 통계를 조회한다.
+
+```bash
+curl -H "X-API-Key: your-api-key" http://localhost:8000/api/cache/stats
+```
+
+```json
+{
+  "entry_count": 42,
+  "total_bytes": 102400,
+  "modules": {
+    "geocode": {"hits": 10, "misses": 3, "hit_rate": 0.7692}
+  }
+}
+```
 
 ### `GET /api/descriptions/{cog_image_id}`
 


### PR DESCRIPTION
## Summary

- `CHANGELOG.md`에 v0.14.0 ~ v0.17.0 변경 이력 추가 (PR #119, #120, #123, #114, #110, #105, #104, #100)
- `README.md` 업데이트:
  - `/api/health` 응답 예시를 `HealthResponse` 스키마(status/version/checks)로 갱신 (#126)
  - `captured_at` 필드를 optional로 수정 (v0.3.1 이후 반영)
  - 누락된 엔드포인트 문서 추가: `/api/batch/describe`, `/api/circuits`, `/api/cache/stats`
  - 신규 환경변수 추가: `SHUTDOWN_TIMEOUT`, `REQUEST_TIMEOUT`, `BATCH_CONCURRENCY`

## Test plan

- [ ] README 내 API 예시 curl 명령어 동작 확인
- [ ] CHANGELOG 형식이 Keep a Changelog 규격에 맞는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)