### PR TITLE
chore: bump version to 0.17.3 for Sprint 25

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-descriptor"
-version = "0.17.0"
+version = "0.17.3"
 description = "Image Descriptor Service for COGnito - generates rich descriptions for satellite imagery"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- Version bump to 0.17.3 for Sprint 25 release

## Changes included in this release
- feat: OpenAPI 응답 예시(examples) 추가 (#130)
- test: describer.py 및 routes.py 테스트 커버리지 개선 (#131)

🤖 Generated with [Claude Code](https://claude.com/claude-code)