### PR TITLE
chore: bump version to 0.18.0 for Sprint 26 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2026-03-07
+
+### Added
+
+- API 요청/응답 로깅 미들웨어 개선: latency 측정(ms), 민감 정보 필터링, 시스템 경로 로그 스킵, 4xx/5xx warning 로깅
+- 테스트 커버리지 97.61% 달성 (목표 95%): lifespan 테스트 6개, 데이터 엔드포인트 테스트 3개 추가
+
 ## [0.17.0] - 2026-03-06
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-descriptor"
-version = "0.17.3"
+version = "0.18.0"
 description = "Image Descriptor Service for COGnito - generates rich descriptions for satellite imagery"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

- v0.18.0 버전 업데이트 (Sprint 26 릴리스)
- CHANGELOG.md 업데이트

### Sprint 26 변경사항
- **API 요청/응답 로깅 미들웨어 개선** (#129, PR #135): latency 측정, 민감 정보 필터링, 시스템 경로 스킵, 4xx/5xx warning 로깅
- **테스트 커버리지 97.61% 달성** (#134, PR #136): lifespan 테스트 6개, 데이터 엔드포인트 테스트 3개 추가

## Test plan
- [ ] CI 통과 확인
- [ ] 머지 후 v0.18.0 태그 생성

Generated with [Claude Code](https://claude.com/claude-code)