### PR TITLE
fix: Dockerfile HEALTHCHECK 경로 수정 및 docker-compose 정합성 개선

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,6 @@ USER app
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')" || exit 1
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/api/health')" || exit 1
 
 CMD ["python", "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,13 +5,15 @@ services:
       - "8080:8080"
     env_file:
       - .env
+    environment:
+      - SUPABASE_URL=${SUPABASE_URL:-https://your-project.supabase.co}
+      - SUPABASE_KEY=${SUPABASE_KEY:-your-anon-key}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-your-api-key}
+      - CACHE_DB_PATH=/tmp/cache/cache.db
     volumes:
       - cache-data:/tmp/cache
-    depends_on:
-      redis:
-        condition: service_healthy
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/api/health')"]
       interval: 30s
       timeout: 5s
       start_period: 10s
@@ -19,23 +21,8 @@ services:
     networks:
       - internal
 
-  redis:
-    image: redis:7-alpine
-    ports:
-      - "6379:6379"
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
-      timeout: 3s
-      retries: 3
-    volumes:
-      - redis-data:/data
-    networks:
-      - internal
-
 volumes:
   cache-data:
-  redis-data:
 
 networks:
   internal:


### PR DESCRIPTION
## Summary
- HEALTHCHECK URL을 `/health`에서 `/api/health`로 수정 (컨테이너가 항상 unhealthy로 판정되던 버그 해결)
- 미사용 `redis` 서비스 및 관련 볼륨/네트워크 의존성 제거
- `docker-compose.yml`에 환경변수 기본값 예시 추가

closes #138

## Test plan
- [x] 기존 테스트 309개 통과 확인
- [ ] Docker build 후 `docker inspect --format='{{.State.Health.Status}}'`로 healthy 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)