### PR TITLE
chore: bump version to 0.19.0 for Sprint 27 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-descriptor"
-version = "0.18.0"
+version = "0.19.0"
 description = "Image Descriptor Service for COGnito - generates rich descriptions for satellite imagery"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- 스프린트 27 릴리스를 위한 버전 범프 (0.18.0 → 0.19.0)

## Sprint 27 변경사항
- **PR #140**: Dockerfile HEALTHCHECK 경로 수정 (`/health` → `/api/health`), 미사용 Redis 서비스 제거
- **PR #141**: 설명 이력 목록 조회 API 추가 (`GET /api/descriptions`) - 페이지네이션, 날짜 필터, Pydantic 타입 안전성

🤖 Generated with [Claude Code](https://claude.com/claude-code)