### PR TITLE
feat: 요청 추적 correlation ID 도입

### DIFF
--- a/app/utils/logging.py
+++ b/app/utils/logging.py
@@ -57,6 +57,10 @@ def generate_request_id() -> str:
     return uuid.uuid4().hex[:16]
 
 
+def generate_correlation_id() -> str:
+    return str(uuid.uuid4())
+
+
 def _sanitize_request_id(value: str | None) -> str | None:
     """Validate and sanitize a client-provided request ID."""
     if value and _VALID_REQUEST_ID.match(value):
@@ -81,13 +85,28 @@ def _safe_query_params(query_string: str) -> str:
     )
 
 
+def _sanitize_correlation_id(value: str | None) -> str | None:
+    """Validate a client-provided correlation ID (UUID format)."""
+    if not value:
+        return None
+    try:
+        return str(uuid.UUID(value))
+    except (ValueError, AttributeError):
+        return None
+
+
 async def request_id_middleware(request: Request, call_next):
-    """Middleware that binds a unique request_id to each request's log context."""
+    """Middleware that binds a unique request_id and correlation_id to each request's log context."""
     request_id = _sanitize_request_id(request.headers.get("x-request-id")) or generate_request_id()
+    correlation_id = (
+        _sanitize_correlation_id(request.headers.get("x-correlation-id"))
+        or generate_correlation_id()
+    )
     request.state.request_id = request_id
+    request.state.correlation_id = correlation_id
 
     structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(request_id=request_id)
+    structlog.contextvars.bind_contextvars(request_id=request_id, correlation_id=correlation_id)
 
     path = request.url.path
     skip_log = path in _SKIP_LOG_PATHS
@@ -108,6 +127,7 @@ async def request_id_middleware(request: Request, call_next):
 
     latency_ms = round((time.monotonic() - start_time) * 1000, 2)
     response.headers["X-Request-ID"] = request_id
+    response.headers["X-Correlation-ID"] = correlation_id
 
     if not skip_log:
         log_method = logger.awarning if response.status_code >= 400 else logger.ainfo

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -9,7 +9,9 @@ from app.main import app
 from app.utils.logging import (
     _safe_headers,
     _safe_query_params,
+    _sanitize_correlation_id,
     _sanitize_request_id,
+    generate_correlation_id,
     generate_request_id,
     setup_logging,
 )
@@ -93,6 +95,67 @@ class TestRequestIdMiddleware:
         rid = resp.headers["x-request-id"]
         assert rid != "<script>alert(1)</script>"
         assert len(rid) == 16
+
+
+class TestGenerateCorrelationId:
+    def test_returns_valid_uuid(self):
+        cid = generate_correlation_id()
+        import uuid
+
+        parsed = uuid.UUID(cid)
+        assert str(parsed) == cid
+
+    def test_unique_ids(self):
+        ids = {generate_correlation_id() for _ in range(100)}
+        assert len(ids) == 100
+
+
+class TestSanitizeCorrelationId:
+    def test_valid_uuid(self):
+        valid = "550e8400-e29b-41d4-a716-446655440000"
+        assert _sanitize_correlation_id(valid) == valid
+
+    def test_rejects_invalid(self):
+        assert _sanitize_correlation_id("not-a-uuid") is None
+
+    def test_rejects_script_injection(self):
+        assert _sanitize_correlation_id("<script>alert(1)</script>") is None
+
+    def test_none_input(self):
+        assert _sanitize_correlation_id(None) is None
+
+    def test_empty_string(self):
+        assert _sanitize_correlation_id("") is None
+
+
+class TestCorrelationIdMiddleware:
+    async def test_response_includes_correlation_id(self, client):
+        resp = await client.get("/api/health")
+        assert "x-correlation-id" in resp.headers
+        import uuid
+
+        uuid.UUID(resp.headers["x-correlation-id"])  # should not raise
+
+    async def test_custom_correlation_id_passthrough(self, client):
+        custom_id = "550e8400-e29b-41d4-a716-446655440000"
+        resp = await client.get("/api/health", headers={"X-Correlation-ID": custom_id})
+        assert resp.headers["x-correlation-id"] == custom_id
+
+    async def test_invalid_correlation_id_replaced(self, client):
+        resp = await client.get(
+            "/api/health",
+            headers={"X-Correlation-ID": "not-a-valid-uuid"},
+        )
+        cid = resp.headers["x-correlation-id"]
+        assert cid != "not-a-valid-uuid"
+        import uuid
+
+        uuid.UUID(cid)  # should be a valid UUID
+
+    async def test_different_requests_get_different_ids(self, client):
+        resp1 = await client.get("/api/health")
+        resp2 = await client.get("/api/health")
+        assert resp1.headers["x-correlation-id"] != resp2.headers["x-correlation-id"]
 
 
 class TestSafeHeaders:


### PR DESCRIPTION
## Summary
- 각 API 요청에 UUID 기반 `correlation_id`를 부여하여 요청 단위 로그 추적 지원
- 클라이언트가 `X-Correlation-ID` 헤더로 ID를 제공하면 그대로 사용 (UUID 검증)
- 응답 헤더 `X-Correlation-ID`로 클라이언트에 전달
- structlog contextvars에 자동 바인딩되어 모든 하위 모듈 로그에 포함

## Changes
- `app/utils/logging.py`: `generate_correlation_id()`, `_sanitize_correlation_id()` 추가, 미들웨어 통합
- `tests/test_logging.py`: correlation ID 관련 테스트 11건 추가

## Test plan
- [x] 기존 332개 테스트 통과 확인
- [x] correlation ID 생성/검증/미들웨어 테스트 11건 통과

closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)