### PR TITLE
docs: correlation ID 헤더 문서화 (#147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `DELETE /api/descriptions/{cog_image_id}`: 저장된 분석 결과 삭제 API (204 성공, 404 미존재, 500 DB 오류)
 - `GET /api/descriptions`: 설명 이력 목록 조회 API
+- Correlation ID 지원: 모든 요청에 `X-Correlation-ID` 헤더를 통해 요청 추적 가능. 클라이언트가 헤더를 제공하면 UUID 검증 후 통과, 없으면 서버에서 자동 생성. 응답 헤더에 항상 포함됨.
 
 ## [0.18.0] - 2026-03-07
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ uv run uvicorn app.main:app --reload
 X-API-Key: your-api-key
 ```
 
+## 요청 추적 헤더
+
+| 헤더 | 방향 | 설명 |
+|------|------|------|
+| `X-Request-ID` | 요청/응답 | 단일 요청 식별자 (클라이언트 제공 또는 서버 자동 생성) |
+| `X-Correlation-ID` | 요청/응답 | 연관 요청 추적 ID (UUID 형식). 클라이언트 제공 시 그대로 반환, 없으면 서버에서 UUID 자동 생성 |
+
+```bash
+curl -H "X-API-Key: your-api-key" \
+     -H "X-Correlation-ID: 550e8400-e29b-41d4-a716-446655440000" \
+     http://localhost:8000/api/health
+```
+
 ## API 레퍼런스
 
 ### `GET /api/health`

--- a/app/utils/logging.py
+++ b/app/utils/logging.py
@@ -58,6 +58,7 @@ def generate_request_id() -> str:
 
 
 def generate_correlation_id() -> str:
+    """Generate a new UUID v4-based correlation ID."""
     return str(uuid.uuid4())
 
 


### PR DESCRIPTION
## Summary

- CHANGELOG `[Unreleased]`에 `X-Correlation-ID` 지원 항목 추가
- README에 **요청 추적 헤더** 섹션 신설 (`X-Request-ID`, `X-Correlation-ID` 설명 및 예시)
- `generate_correlation_id()` 함수에 docstring 추가

## 관련 이슈

closes #147 (correlation ID 도입 — PR #148 문서화)

## Test plan

- [ ] README 렌더링 확인 (헤더 테이블, curl 예시)
- [ ] CHANGELOG 형식 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)