### PR TITLE
chore: bump version to 0.20.0 for Sprint 29 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-03-07
+
 ### Added
 
 - `DELETE /api/descriptions/{cog_image_id}`: 저장된 분석 결과 삭제 API (204 성공, 404 미존재, 500 DB 오류)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-descriptor"
-version = "0.19.0"
+version = "0.20.0"
 description = "Image Descriptor Service for COGnito - generates rich descriptions for satellite imagery"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- 버전 0.19.0 → 0.20.0 범프
- CHANGELOG.md에 v0.20.0 릴리스 항목 추가

## Sprint 29 포함 사항
- Correlation ID 요청 추적 기능 (#147, PR #148)
- Correlation ID 문서화 (PR #149)
- DELETE /api/descriptions API, GET /api/descriptions API

🤖 Generated with [Claude Code](https://claude.com/claude-code)