### PR TITLE
chore: bump version to 0.21.0 for Sprint 29 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.20.0] - 2026-03-07
+## [0.21.0] - 2026-03-07
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-descriptor"
-version = "0.20.0"
+version = "0.21.0"
 description = "Image Descriptor Service for COGnito - generates rich descriptions for satellite imagery"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- 버전 0.20.0 → 0.21.0 범프
- CHANGELOG.md 버전 태그 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)