### PR TITLE
chore: bump version to 0.23.0 for Sprint 31 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-03-07
+
+### Added
+
+- 캐시 DB 마이그레이션 버전 관리 체계: `schema_version` 테이블 기반 경량 마이그레이션 러너 도입, 기존 cache 테이블 스키마를 v1 마이그레이션으로 변환 (#144, #157)
+- Graceful Shutdown 테스트 보강: in-flight 카운터, drain event, `is_shutting_down()`, `shutdown_timeout` 설정 외부화 검증 테스트 추가 (#156, #158)
+
 ## [0.22.0] - 2026-03-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-descriptor"
-version = "0.22.0"
+version = "0.23.0"
 description = "Image Descriptor Service for COGnito - generates rich descriptions for satellite imagery"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

- 캐시 DB 마이그레이션 버전 관리 체계 도입 (#144, #157)
- Graceful Shutdown 테스트 보강 (#156, #158)
- 버전 0.22.0 → 0.23.0, CHANGELOG 업데이트

## Test plan

- [ ] 전체 테스트 통과 확인
- [ ] 버전 번호 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)