### PR TITLE
chore: bump version to 0.24.0 for Sprint 32 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-03-07
+
 ### Added
 
 - RFC 7807 Problem Details 에러 응답 표준화: `ProblemDetail` 모델(`type`, `title`, `status`, `detail`, `instance`) 도입. `ValidationError`(422), `HTTPException`, 내부 오류(500), 타임아웃(504) 모두 통일된 형식으로 반환

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-descriptor"
-version = "0.22.0"
+version = "0.24.0"
 description = "Image Descriptor Service for COGnito - generates rich descriptions for satellite imagery"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- 버전 0.22.0 → 0.24.0 범프
- CHANGELOG.md에 v0.24.0 섹션 추가 (RFC 7807, OpenAPI examples)

## Sprint 32 포함 내용
- PR #162: RFC 7807 Problem Details 에러 응답 표준화
- PR #163: OpenAPI examples 및 description 보강
- PR #164: 관련 문서화 (CHANGELOG, integration-guide)

## Test plan
- [ ] CI 테스트 통과 확인
- [ ] 버전 번호 정상 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)