### PR TITLE
feat: API 버전 관리 (v1 prefix) 도입

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,6 @@ USER app
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/api/health')" || exit 1
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/api/v1/health')" || exit 1
 
 CMD ["python", "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/app/main.py
+++ b/app/main.py
@@ -4,10 +4,10 @@ from contextlib import asynccontextmanager
 from importlib.metadata import PackageNotFoundError, version
 
 import structlog
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from prometheus_fastapi_instrumentator import Instrumentator
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
@@ -208,6 +208,17 @@ async def security_headers_middleware(request, call_next):
     return response
 
 
-app.include_router(router, prefix="/api")
+app.include_router(router, prefix="/api/v1")
+
+
+@app.api_route("/api/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"], include_in_schema=False)
+async def legacy_api_redirect(request: Request, path: str):
+    """Redirect legacy /api/* requests to /api/v1/* for backward compatibility."""
+    query_string = request.url.query
+    new_url = f"/api/v1/{path}"
+    if query_string:
+        new_url = f"{new_url}?{query_string}"
+    return RedirectResponse(url=new_url, status_code=307)
+
 
 Instrumentator().instrument(app).expose(app, endpoint="/metrics", include_in_schema=False)

--- a/app/utils/logging.py
+++ b/app/utils/logging.py
@@ -23,6 +23,8 @@ _SKIP_LOG_PATHS = frozenset(
     {
         "/health",
         "/metrics",
+        "/api/v1/health",
+        "/api/v1/cache/stats",
         "/api/health",
         "/api/cache/stats",
     }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,7 +38,7 @@ async def test_health(client_with_cache):
             return True
 
         mp.setattr(supabase_mod, "ping", _mock_ping)
-        resp = await client_with_cache.get("/api/health")
+        resp = await client_with_cache.get("/api/v1/health")
     assert resp.status_code == 200
     data = resp.json()
     assert data["status"] == "ok"
@@ -49,7 +49,7 @@ async def test_health(client_with_cache):
 
 async def test_describe_no_api_key(client):
     resp = await client.post(
-        "/api/describe",
+        "/api/v1/describe",
         json={
             "thumbnail": "dGVzdA==",
             "coordinates": [126.978, 37.566],
@@ -61,7 +61,7 @@ async def test_describe_no_api_key(client):
 
 async def test_describe_invalid_coordinates(client):
     resp = await client.post(
-        "/api/describe",
+        "/api/v1/describe",
         json={
             "thumbnail": "dGVzdA==",
             "coordinates": [999, 999],
@@ -83,7 +83,7 @@ async def test_describe_invalid_coordinates(client):
 )
 async def test_describe_invalid_bbox(client, bbox):
     resp = await client.post(
-        "/api/describe",
+        "/api/v1/describe",
         json={
             "thumbnail": "dGVzdA==",
             "coordinates": [126.978, 37.566],
@@ -107,7 +107,7 @@ def test_describe_bbox_null_accepted():
 
 async def test_describe_thumbnail_too_large(client):
     resp = await client.post(
-        "/api/describe",
+        "/api/v1/describe",
         json={
             "thumbnail": "x" * (5 * 1024 * 1024 + 1),
             "coordinates": [126.978, 37.566],
@@ -119,11 +119,11 @@ async def test_describe_thumbnail_too_large(client):
 
 
 async def test_get_description_no_auth(client):
-    resp = await client.get("/api/descriptions/some-id")
+    resp = await client.get("/api/v1/descriptions/some-id")
     assert resp.status_code == 401
 
 
-@pytest.mark.parametrize("endpoint", ["/api/geocode", "/api/landcover", "/api/context"])
+@pytest.mark.parametrize("endpoint", ["/api/v1/geocode", "/api/v1/landcover", "/api/v1/context"])
 async def test_invalid_coordinates_on_sub_endpoints(client, endpoint):
     resp = await client.post(
         endpoint,
@@ -136,7 +136,7 @@ async def test_invalid_coordinates_on_sub_endpoints(client, endpoint):
     assert resp.status_code == 422
 
 
-@pytest.mark.parametrize("endpoint", ["/api/geocode", "/api/landcover", "/api/context"])
+@pytest.mark.parametrize("endpoint", ["/api/v1/geocode", "/api/v1/landcover", "/api/v1/context"])
 async def test_valid_coordinates_require_auth_on_sub_endpoints(client, endpoint):
     resp = await client.post(
         endpoint,
@@ -149,7 +149,7 @@ async def test_valid_coordinates_require_auth_on_sub_endpoints(client, endpoint)
 
 
 async def test_cache_stats_endpoint(client_with_cache):
-    resp = await client_with_cache.get("/api/cache/stats")
+    resp = await client_with_cache.get("/api/v1/cache/stats")
     assert resp.status_code == 200
     data = resp.json()
     assert "entry_count" in data
@@ -169,7 +169,7 @@ async def test_cache_stats_after_hit_miss(client_with_cache):
     result = await cache.get("geocode:127:37")
     assert result is not None
 
-    resp = await client_with_cache.get("/api/cache/stats")
+    resp = await client_with_cache.get("/api/v1/cache/stats")
     data = resp.json()
     assert data["entry_count"] == 1
     geocode_stats = data["modules"]["geocode"]
@@ -204,9 +204,9 @@ async def test_rate_limit_returns_429(tmp_path):
                     "captured_at": "2025-06-15T00:00:00Z",
                 }
                 # First request consumes the 1/minute limit
-                await c.post("/api/describe", json=body, headers=headers)
+                await c.post("/api/v1/describe", json=body, headers=headers)
                 # Second request should be rate limited
-                resp2 = await c.post("/api/describe", json=body, headers=headers)
+                resp2 = await c.post("/api/v1/describe", json=body, headers=headers)
                 assert resp2.status_code == 429
     finally:
         limiter.reset()
@@ -222,7 +222,7 @@ async def test_health_no_rate_limit(client_with_cache, monkeypatch):
 
     monkeypatch.setattr(supabase_mod, "ping", _mock_ping)
     for _ in range(5):
-        resp = await client_with_cache.get("/api/health")
+        resp = await client_with_cache.get("/api/v1/health")
         assert resp.status_code == 200
 
 
@@ -233,7 +233,7 @@ async def test_request_id_header(client_with_cache, monkeypatch):
         return True
 
     monkeypatch.setattr(supabase_mod, "ping", _mock_ping)
-    resp = await client_with_cache.get("/api/health")
+    resp = await client_with_cache.get("/api/v1/health")
     assert resp.status_code == 200
     assert "x-request-id" in resp.headers
     assert len(resp.headers["x-request-id"]) == 16
@@ -247,7 +247,7 @@ async def test_request_id_passthrough(client_with_cache, monkeypatch):
 
     monkeypatch.setattr(supabase_mod, "ping", _mock_ping)
     custom_id = "my-custom-request-id"
-    resp = await client_with_cache.get("/api/health", headers={"X-Request-ID": custom_id})
+    resp = await client_with_cache.get("/api/v1/health", headers={"X-Request-ID": custom_id})
     assert resp.headers["x-request-id"] == custom_id
 
 
@@ -343,7 +343,7 @@ class TestDescribeCacheHeaders:
     async def test_describe_returns_etag_header(self, _mock_describe):
         client, _ = _mock_describe
         resp = await client.post(
-            "/api/describe",
+            "/api/v1/describe",
             json={"thumbnail": "dGVzdA==", "coordinates": [126.978, 37.566]},
             headers={"X-API-Key": os.environ["API_KEY"]},
         )
@@ -362,7 +362,7 @@ class TestDescribeCacheHeaders:
             AsyncMock(return_value=mock_result),
         )
         resp = await client_with_cache.post(
-            "/api/describe",
+            "/api/v1/describe",
             json={"thumbnail": "dGVzdA==", "coordinates": [126.978, 37.566]},
             headers={"X-API-Key": os.environ["API_KEY"]},
         )
@@ -374,17 +374,17 @@ class TestDescribeCacheHeaders:
         body = {"thumbnail": "dGVzdA==", "coordinates": [126.978, 37.566]}
         headers = {"X-API-Key": os.environ["API_KEY"]}
 
-        resp1 = await client.post("/api/describe", json=body, headers=headers)
+        resp1 = await client.post("/api/v1/describe", json=body, headers=headers)
         etag = resp1.headers["etag"]
 
         headers["If-None-Match"] = etag
-        resp2 = await client.post("/api/describe", json=body, headers=headers)
+        resp2 = await client.post("/api/v1/describe", json=body, headers=headers)
         assert resp2.status_code == 304
 
     async def test_describe_200_with_mismatched_etag(self, _mock_describe):
         client, _ = _mock_describe
         resp = await client.post(
-            "/api/describe",
+            "/api/v1/describe",
             json={"thumbnail": "dGVzdA==", "coordinates": [126.978, 37.566]},
             headers={
                 "X-API-Key": os.environ["API_KEY"],
@@ -399,15 +399,15 @@ class TestDescribeCacheHeaders:
         body = {"thumbnail": "dGVzdA==", "coordinates": [126.978, 37.566]}
         headers = {"X-API-Key": os.environ["API_KEY"]}
 
-        resp1 = await client.post("/api/describe", json=body, headers=headers)
-        resp2 = await client.post("/api/describe", json=body, headers=headers)
+        resp1 = await client.post("/api/v1/describe", json=body, headers=headers)
+        resp2 = await client.post("/api/v1/describe", json=body, headers=headers)
         assert resp1.headers["etag"] == resp2.headers["etag"]
 
     async def test_etag_format_is_quoted_string(self, _mock_describe):
         """ETag must be a quoted string per HTTP spec."""
         client, _ = _mock_describe
         resp = await client.post(
-            "/api/describe",
+            "/api/v1/describe",
             json={"thumbnail": "dGVzdA==", "coordinates": [126.978, 37.566]},
             headers={"X-API-Key": os.environ["API_KEY"]},
         )
@@ -421,11 +421,11 @@ class TestDescribeCacheHeaders:
         body = {"thumbnail": "dGVzdA==", "coordinates": [126.978, 37.566]}
         headers = {"X-API-Key": os.environ["API_KEY"]}
 
-        resp1 = await client.post("/api/describe", json=body, headers=headers)
+        resp1 = await client.post("/api/v1/describe", json=body, headers=headers)
         etag = resp1.headers["etag"]
 
         headers["If-None-Match"] = etag
-        resp2 = await client.post("/api/describe", json=body, headers=headers)
+        resp2 = await client.post("/api/v1/describe", json=body, headers=headers)
         assert resp2.status_code == 304
         assert resp2.headers["etag"] == etag
 
@@ -435,10 +435,10 @@ class TestDescribeCacheHeaders:
         body = {"thumbnail": "dGVzdA==", "coordinates": [126.978, 37.566]}
         headers = {"X-API-Key": os.environ["API_KEY"]}
 
-        resp1 = await client.post("/api/describe", json=body, headers=headers)
+        resp1 = await client.post("/api/v1/describe", json=body, headers=headers)
         headers["If-None-Match"] = resp1.headers["etag"]
 
-        resp2 = await client.post("/api/describe", json=body, headers=headers)
+        resp2 = await client.post("/api/v1/describe", json=body, headers=headers)
         assert resp2.status_code == 304
         assert resp2.content == b""
 
@@ -456,14 +456,14 @@ class TestDescribeCacheHeaders:
             "app.api.routes._describe_and_save",
             AsyncMock(return_value=mock1),
         )
-        resp1 = await client_with_cache.post("/api/describe", json=body, headers=headers)
+        resp1 = await client_with_cache.post("/api/v1/describe", json=body, headers=headers)
 
         mock2 = DescribeResponse(description="second description", cached=False)
         monkeypatch.setattr(
             "app.api.routes._describe_and_save",
             AsyncMock(return_value=mock2),
         )
-        resp2 = await client_with_cache.post("/api/describe", json=body, headers=headers)
+        resp2 = await client_with_cache.post("/api/v1/describe", json=body, headers=headers)
 
         assert resp1.headers["etag"] != resp2.headers["etag"]
 
@@ -471,7 +471,7 @@ class TestDescribeCacheHeaders:
         """Request without If-None-Match must always return 200 with full body."""
         client, _ = _mock_describe
         resp = await client.post(
-            "/api/describe",
+            "/api/v1/describe",
             json={"thumbnail": "dGVzdA==", "coordinates": [126.978, 37.566]},
             headers={"X-API-Key": os.environ["API_KEY"]},
         )
@@ -491,7 +491,7 @@ async def test_health_degraded_when_supabase_fails(client_with_cache, monkeypatc
 
     monkeypatch.setattr(supabase_mod, "ping", _supabase_fail)
     # cache.ping is already ok since it's a real cache
-    resp = await client_with_cache.get("/api/health")
+    resp = await client_with_cache.get("/api/v1/health")
     data = resp.json()
     assert data["status"] in ("degraded", "shutting_down")
     assert data["checks"]["supabase"] == "fail"
@@ -505,7 +505,7 @@ async def test_health_unhealthy_when_all_fail(client_with_cache, monkeypatch):
 
     monkeypatch.setattr(supabase_mod, "ping", _fail)
     monkeypatch.setattr(app.state.cache, "ping", _fail)
-    resp = await client_with_cache.get("/api/health")
+    resp = await client_with_cache.get("/api/v1/health")
     assert resp.status_code == 503
     data = resp.json()
     assert data["status"] in ("unhealthy", "shutting_down")
@@ -516,7 +516,7 @@ async def test_get_description_not_found(client_with_cache, monkeypatch):
 
     monkeypatch.setattr(db_mod, "get_description", AsyncMock(return_value=None))
     resp = await client_with_cache.get(
-        "/api/descriptions/nonexistent-id",
+        "/api/v1/descriptions/nonexistent-id",
         headers={"X-API-Key": os.environ["API_KEY"]},
     )
     assert resp.status_code == 404
@@ -531,7 +531,7 @@ async def test_get_description_found(client_with_cache, monkeypatch):
     mock_data = {"description": "test", "cog_image_id": "found-id"}
     monkeypatch.setattr(db_mod, "get_description", AsyncMock(return_value=mock_data))
     resp = await client_with_cache.get(
-        "/api/descriptions/found-id",
+        "/api/v1/descriptions/found-id",
         headers={"X-API-Key": os.environ["API_KEY"]},
     )
     assert resp.status_code == 200
@@ -544,7 +544,7 @@ async def test_list_descriptions(client_with_cache, monkeypatch):
     mock_result = {"items": [{"cog_image_id": "id-1"}], "total": 1}
     monkeypatch.setattr(db_mod, "list_descriptions", AsyncMock(return_value=mock_result))
     resp = await client_with_cache.get(
-        "/api/descriptions",
+        "/api/v1/descriptions",
         headers={"X-API-Key": os.environ["API_KEY"]},
     )
     assert resp.status_code == 200
@@ -556,7 +556,7 @@ async def test_list_descriptions(client_with_cache, monkeypatch):
 
 
 async def test_list_descriptions_no_auth(client):
-    resp = await client.get("/api/descriptions")
+    resp = await client.get("/api/v1/descriptions")
     assert resp.status_code == 401
 
 
@@ -566,7 +566,7 @@ async def test_shutdown_middleware_rejects_non_system_paths(client_with_cache, m
 
     monkeypatch.setattr(main_mod, "_shutting_down", True)
     resp = await client_with_cache.post(
-        "/api/describe",
+        "/api/v1/describe",
         json={"thumbnail": "dGVzdA==", "coordinates": [126.978, 37.566]},
         headers={"X-API-Key": os.environ["API_KEY"]},
     )
@@ -581,7 +581,7 @@ async def test_shutdown_middleware_allows_health(client_with_cache, monkeypatch)
 
     monkeypatch.setattr(main_mod, "_shutting_down", True)
     monkeypatch.setattr(supabase_mod, "ping", AsyncMock(return_value=True))
-    resp = await client_with_cache.get("/api/health")
+    resp = await client_with_cache.get("/api/v1/health")
     # Health endpoint is allowed through shutdown middleware but returns 503 with shutting_down
     assert resp.status_code in (200, 503)
     assert resp.json()["status"] == "shutting_down"
@@ -599,7 +599,7 @@ class TestRequestIdValidation:
 
         monkeypatch.setattr(supabase_mod, "ping", self._mock_ping)
         resp = await client_with_cache.get(
-            "/api/health",
+            "/api/v1/health",
             headers={"X-Request-ID": "evil\nheader\r\ninjection"},
         )
         assert resp.status_code == 200
@@ -613,7 +613,7 @@ class TestRequestIdValidation:
 
         monkeypatch.setattr(supabase_mod, "ping", self._mock_ping)
         resp = await client_with_cache.get(
-            "/api/health",
+            "/api/v1/health",
             headers={"X-Request-ID": "a" * 200},
         )
         rid = resp.headers["x-request-id"]
@@ -626,14 +626,14 @@ class TestRequestIdValidation:
         monkeypatch.setattr(supabase_mod, "ping", self._mock_ping)
         custom_id = "req-123_abc-XYZ"
         resp = await client_with_cache.get(
-            "/api/health",
+            "/api/v1/health",
             headers={"X-Request-ID": custom_id},
         )
         assert resp.headers["x-request-id"] == custom_id
 
 
 async def test_delete_description_no_auth(client):
-    resp = await client.delete("/api/descriptions/some-id")
+    resp = await client.delete("/api/v1/descriptions/some-id")
     assert resp.status_code == 401
 
 
@@ -642,7 +642,7 @@ async def test_delete_description_not_found(client_with_cache, monkeypatch):
 
     monkeypatch.setattr(db_mod, "delete_description", AsyncMock(return_value=False))
     resp = await client_with_cache.delete(
-        "/api/descriptions/nonexistent-id",
+        "/api/v1/descriptions/nonexistent-id",
         headers={"X-API-Key": os.environ["API_KEY"]},
     )
     assert resp.status_code == 404
@@ -656,7 +656,7 @@ async def test_delete_description_success(client_with_cache, monkeypatch):
 
     monkeypatch.setattr(db_mod, "delete_description", AsyncMock(return_value=True))
     resp = await client_with_cache.delete(
-        "/api/descriptions/existing-id",
+        "/api/v1/descriptions/existing-id",
         headers={"X-API-Key": os.environ["API_KEY"]},
     )
     assert resp.status_code == 204
@@ -670,7 +670,7 @@ async def test_delete_description_db_error_returns_500(client_with_cache, monkey
         db_mod, "delete_description", AsyncMock(side_effect=Exception("db error"))
     )
     resp = await client_with_cache.delete(
-        "/api/descriptions/some-id",
+        "/api/v1/descriptions/some-id",
         headers={"X-API-Key": os.environ["API_KEY"]},
     )
     assert resp.status_code == 500
@@ -684,7 +684,7 @@ class TestRFC7807ProblemDetail:
 
     async def test_validation_error_returns_problem_detail(self, client_with_cache):
         resp = await client_with_cache.post(
-            "/api/describe",
+            "/api/v1/describe",
             json={"thumbnail": "test", "coordinates": [999, 999]},
             headers={"X-API-Key": os.environ["API_KEY"]},
         )
@@ -702,7 +702,7 @@ class TestRFC7807ProblemDetail:
 
         monkeypatch.setattr(db_mod, "get_description", AsyncMock(return_value=None))
         resp = await client_with_cache.get(
-            "/api/descriptions/nonexistent",
+            "/api/v1/descriptions/nonexistent",
             headers={"X-API-Key": os.environ["API_KEY"]},
         )
         assert resp.status_code == 404
@@ -720,7 +720,7 @@ class TestRFC7807ProblemDetail:
         monkeypatch.setattr(db_mod, "get_description", AsyncMock(return_value=None))
         custom_cid = "550e8400-e29b-41d4-a716-446655440000"
         resp = await client_with_cache.get(
-            "/api/descriptions/nonexistent",
+            "/api/v1/descriptions/nonexistent",
             headers={
                 "X-API-Key": os.environ["API_KEY"],
                 "X-Correlation-ID": custom_cid,
@@ -738,7 +738,7 @@ class TestRFC7807ProblemDetail:
             db_mod, "get_description", AsyncMock(side_effect=HTTPException(status_code=400, detail="bad input"))
         )
         resp = await client_with_cache.get(
-            "/api/descriptions/some-id",
+            "/api/v1/descriptions/some-id",
             headers={"X-API-Key": os.environ["API_KEY"]},
         )
         assert resp.status_code == 400
@@ -787,7 +787,7 @@ class TestRFC7807ProblemDetail:
             ),
         )
         resp = await client_with_cache.get(
-            "/api/descriptions/bad-id",
+            "/api/v1/descriptions/bad-id",
             headers={"X-API-Key": os.environ["API_KEY"]},
         )
         assert resp.status_code == 422
@@ -803,7 +803,7 @@ class TestCORSPreflight:
     async def test_delete_preflight_allowed(self, client):
         """DELETE 메서드에 대한 CORS preflight가 허용되어야 한다."""
         resp = await client.options(
-            "/api/descriptions/some-id",
+            "/api/v1/descriptions/some-id",
             headers={
                 "Origin": "http://localhost:5173",
                 "Access-Control-Request-Method": "DELETE",
@@ -816,7 +816,7 @@ class TestCORSPreflight:
     async def test_get_preflight_allowed(self, client):
         """GET 메서드에 대한 CORS preflight가 허용되어야 한다."""
         resp = await client.options(
-            "/api/descriptions/some-id",
+            "/api/v1/descriptions/some-id",
             headers={
                 "Origin": "http://localhost:5173",
                 "Access-Control-Request-Method": "GET",
@@ -829,7 +829,7 @@ class TestCORSPreflight:
     async def test_post_preflight_allowed(self, client):
         """POST 메서드에 대한 CORS preflight가 허용되어야 한다."""
         resp = await client.options(
-            "/api/describe",
+            "/api/v1/describe",
             headers={
                 "Origin": "http://localhost:3000",
                 "Access-Control-Request-Method": "POST",
@@ -838,3 +838,27 @@ class TestCORSPreflight:
         )
         assert resp.status_code == 200
         assert "POST" in resp.headers.get("access-control-allow-methods", "")
+
+
+class TestLegacyApiRedirect:
+    """Legacy /api/* → /api/v1/* redirect tests."""
+
+    async def test_legacy_get_redirects(self, client_with_cache):
+        resp = await client_with_cache.get("/api/health")
+        assert resp.status_code == 307
+        assert resp.headers["location"] == "/api/v1/health"
+
+    async def test_legacy_post_redirects(self, client):
+        resp = await client.post("/api/describe", json={})
+        assert resp.status_code == 307
+        assert resp.headers["location"] == "/api/v1/describe"
+
+    async def test_legacy_delete_redirects(self, client):
+        resp = await client.delete("/api/descriptions/some-id")
+        assert resp.status_code == 307
+        assert resp.headers["location"] == "/api/v1/descriptions/some-id"
+
+    async def test_legacy_redirect_preserves_query_params(self, client):
+        resp = await client.get("/api/descriptions?offset=10&limit=5")
+        assert resp.status_code == 307
+        assert resp.headers["location"] == "/api/v1/descriptions?offset=10&limit=5"

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -42,7 +42,7 @@ def _mock_response():
 )
 async def test_batch_success(mock_compose, client_with_cache):
     resp = await client_with_cache.post(
-        "/api/describe/batch",
+        "/api/v1/describe/batch",
         json={"items": [_make_item(), _make_item()]},
     )
     assert resp.status_code == 200
@@ -65,7 +65,7 @@ async def test_batch_partial_failure(mock_compose, client_with_cache):
         Exception("external service failed"),
     ]
     resp = await client_with_cache.post(
-        "/api/describe/batch",
+        "/api/v1/describe/batch",
         json={"items": [_make_item(), _make_item()]},
     )
     assert resp.status_code == 200
@@ -79,7 +79,7 @@ async def test_batch_partial_failure(mock_compose, client_with_cache):
 
 async def test_batch_empty_array(client_with_cache):
     resp = await client_with_cache.post(
-        "/api/describe/batch",
+        "/api/v1/describe/batch",
         json={"items": []},
     )
     assert resp.status_code == 422
@@ -87,7 +87,7 @@ async def test_batch_empty_array(client_with_cache):
 
 async def test_batch_exceeds_max(client_with_cache):
     resp = await client_with_cache.post(
-        "/api/describe/batch",
+        "/api/v1/describe/batch",
         json={"items": [_make_item() for _ in range(11)]},
     )
     assert resp.status_code == 422
@@ -99,7 +99,7 @@ async def test_batch_no_auth():
         base_url="http://test",
     ) as c:
         resp = await c.post(
-            "/api/describe/batch",
+            "/api/v1/describe/batch",
             json={"items": [_make_item()]},
         )
     assert resp.status_code == 401
@@ -116,7 +116,7 @@ async def test_batch_thumbnail_too_large(mock_compose, client_with_cache):
         "coordinates": [126.978, 37.566],
     }
     resp = await client_with_cache.post(
-        "/api/describe/batch",
+        "/api/v1/describe/batch",
         json={"items": [_make_item(), large_item]},
     )
     assert resp.status_code == 200

--- a/tests/test_batch_concurrency.py
+++ b/tests/test_batch_concurrency.py
@@ -67,7 +67,7 @@ async def test_batch_concurrency_limited(batch_client, monkeypatch):
 
     items = [{"coordinates": [127.0 + i * 0.01, 37.0], "thumbnail": "dGVzdA=="} for i in range(6)]
 
-    resp = await batch_client.post("/api/describe/batch", json={"items": items})
+    resp = await batch_client.post("/api/v1/describe/batch", json={"items": items})
     assert resp.status_code == 200
     data = resp.json()
     assert data["total"] == 6
@@ -99,7 +99,7 @@ async def test_batch_all_items_processed(batch_client, monkeypatch):
 
     items = [{"coordinates": [127.0, 37.0], "thumbnail": "dGVzdA=="} for _ in range(10)]
 
-    resp = await batch_client.post("/api/describe/batch", json={"items": items})
+    resp = await batch_client.post("/api/v1/describe/batch", json={"items": items})
     assert resp.status_code == 200
     data = resp.json()
     assert data["total"] == 10
@@ -136,7 +136,7 @@ async def test_individual_failure_does_not_affect_others(batch_client, monkeypat
 
     items = [{"coordinates": [127.0, 37.0], "thumbnail": "dGVzdA=="} for _ in range(5)]
 
-    resp = await batch_client.post("/api/describe/batch", json={"items": items})
+    resp = await batch_client.post("/api/v1/describe/batch", json={"items": items})
     assert resp.status_code == 200
     data = resp.json()
     assert data["total"] == 5

--- a/tests/test_cache_stats.py
+++ b/tests/test_cache_stats.py
@@ -126,11 +126,11 @@ class TestCacheStatsEndpoint:
         await store.close()
 
     async def test_endpoint_returns_200(self, client):
-        resp = await client.get("/api/cache/stats")
+        resp = await client.get("/api/v1/cache/stats")
         assert resp.status_code == 200
 
     async def test_endpoint_json_structure(self, client):
-        resp = await client.get("/api/cache/stats")
+        resp = await client.get("/api/v1/cache/stats")
         data = resp.json()
         assert "entry_count" in data
         assert "total_bytes" in data

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -52,11 +52,11 @@ class TestCircuitsEndpoint:
         await store.close()
 
     async def test_endpoint_returns_200(self, client):
-        resp = await client.get("/api/circuits")
+        resp = await client.get("/api/v1/circuits")
         assert resp.status_code == 200
 
     async def test_response_structure(self, client):
-        resp = await client.get("/api/circuits")
+        resp = await client.get("/api/v1/circuits")
         data = resp.json()
         assert "breakers" in data
         assert len(data["breakers"]) == 5
@@ -67,6 +67,6 @@ class TestCircuitsEndpoint:
             assert "cooldown_remaining" in breaker
 
     async def test_all_services_present(self, client):
-        resp = await client.get("/api/circuits")
+        resp = await client.get("/api/v1/circuits")
         names = {b["name"] for b in resp.json()["breakers"]}
         assert names == {"geocoder", "landcover", "describer", "context", "mission"}

--- a/tests/test_data_endpoints.py
+++ b/tests/test_data_endpoints.py
@@ -37,7 +37,7 @@ async def test_geocode_endpoint(auth_client):
     }
     with patch("app.modules.geocoder.geocode", new_callable=AsyncMock, return_value=mock_result):
         resp = await auth_client.post(
-            "/api/geocode",
+            "/api/v1/geocode",
             json={"coordinates": [127.0, 37.5], "thumbnail": "http://example.com/img.png"},
         )
     assert resp.status_code == 200
@@ -56,7 +56,7 @@ async def test_landcover_endpoint(auth_client):
         return_value=mock_result,
     ):
         resp = await auth_client.post(
-            "/api/landcover",
+            "/api/v1/landcover",
             json={"coordinates": [127.0, 37.5], "thumbnail": "http://example.com/img.png"},
         )
     assert resp.status_code == 200
@@ -82,7 +82,7 @@ async def test_context_endpoint(auth_client):
         return_value=mock_result,
     ):
         resp = await auth_client.post(
-            "/api/context",
+            "/api/v1/context",
             json={
                 "coordinates": [127.0, 37.5],
                 "thumbnail": "http://example.com/img.png",

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -13,7 +13,7 @@ import pytest
 async def test_describe_full(authenticated_client):
     """실제 Supabase 썸네일 URL로 /api/describe E2E 테스트."""
     resp = await authenticated_client.post(
-        "/api/describe",
+        "/api/v1/describe",
         json={
             "thumbnail": (
                 "https://nfbvxuwimdjgnegkvzwo.supabase.co/storage/v1/object/public"
@@ -63,7 +63,7 @@ async def test_describe_full(authenticated_client):
 @pytest.mark.e2e
 async def test_geocode_endpoint(authenticated_client):
     resp = await authenticated_client.post(
-        "/api/geocode",
+        "/api/v1/geocode",
         json={
             "thumbnail": "",
             "coordinates": [126.978, 37.566],
@@ -79,7 +79,7 @@ async def test_geocode_endpoint(authenticated_client):
 @pytest.mark.e2e
 async def test_landcover_endpoint(authenticated_client):
     resp = await authenticated_client.post(
-        "/api/landcover",
+        "/api/v1/landcover",
         json={
             "thumbnail": "",
             "coordinates": [126.978, 37.566],

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -28,7 +28,7 @@ async def health_client(tmp_path, monkeypatch):
 
 
 async def test_health_all_ok(health_client):
-    resp = await health_client.get("/api/health")
+    resp = await health_client.get("/api/v1/health")
     assert resp.status_code == 200
     data = resp.json()
     assert data["status"] == "ok"
@@ -51,7 +51,7 @@ async def test_health_supabase_fail(tmp_path, monkeypatch):
         transport=ASGITransport(app=app),
         base_url="http://test",
     ) as c:
-        resp = await c.get("/api/health")
+        resp = await c.get("/api/v1/health")
     await cache.close()
 
     assert resp.status_code == 200
@@ -76,7 +76,7 @@ async def test_health_cache_fail(tmp_path, monkeypatch):
         transport=ASGITransport(app=app),
         base_url="http://test",
     ) as c:
-        resp = await c.get("/api/health")
+        resp = await c.get("/api/v1/health")
 
     assert resp.status_code == 200
     data = resp.json()
@@ -100,7 +100,7 @@ async def test_health_all_fail(tmp_path, monkeypatch):
         transport=ASGITransport(app=app),
         base_url="http://test",
     ) as c:
-        resp = await c.get("/api/health")
+        resp = await c.get("/api/v1/health")
 
     assert resp.status_code == 503
     data = resp.json()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -63,33 +63,33 @@ class TestGenerateRequestId:
 
 class TestRequestIdMiddleware:
     async def test_response_includes_request_id(self, client):
-        resp = await client.get("/api/health")
+        resp = await client.get("/api/v1/health")
         assert "x-request-id" in resp.headers
         assert len(resp.headers["x-request-id"]) == 16
 
     async def test_custom_request_id_passthrough(self, client):
         custom_id = "my-custom-req-id"
-        resp = await client.get("/api/health", headers={"X-Request-ID": custom_id})
+        resp = await client.get("/api/v1/health", headers={"X-Request-ID": custom_id})
         assert resp.headers["x-request-id"] == custom_id
 
     async def test_generated_id_is_hex(self, client):
-        resp = await client.get("/api/health")
+        resp = await client.get("/api/v1/health")
         rid = resp.headers["x-request-id"]
         int(rid, 16)  # should not raise
 
     async def test_different_requests_get_different_ids(self, client):
-        resp1 = await client.get("/api/health")
-        resp2 = await client.get("/api/health")
+        resp1 = await client.get("/api/v1/health")
+        resp2 = await client.get("/api/v1/health")
         assert resp1.headers["x-request-id"] != resp2.headers["x-request-id"]
 
     async def test_security_headers_present(self, client):
-        resp = await client.get("/api/health")
+        resp = await client.get("/api/v1/health")
         assert resp.headers["x-content-type-options"] == "nosniff"
         assert resp.headers["x-frame-options"] == "DENY"
 
     async def test_invalid_request_id_ignored(self, client):
         resp = await client.get(
-            "/api/health",
+            "/api/v1/health",
             headers={"X-Request-ID": "<script>alert(1)</script>"},
         )
         rid = resp.headers["x-request-id"]
@@ -99,17 +99,17 @@ class TestRequestIdMiddleware:
 
 class TestProcessTimeHeader:
     async def test_response_includes_process_time(self, client):
-        resp = await client.get("/api/health")
+        resp = await client.get("/api/v1/health")
         assert "x-process-time" in resp.headers
         process_time = float(resp.headers["x-process-time"])
         assert process_time >= 0
 
     async def test_process_time_is_numeric(self, client):
-        resp = await client.get("/api/health")
+        resp = await client.get("/api/v1/health")
         float(resp.headers["x-process-time"])  # should not raise
 
     async def test_process_time_has_six_decimal_places(self, client):
-        resp = await client.get("/api/health")
+        resp = await client.get("/api/v1/health")
         value = resp.headers["x-process-time"]
         # f"{process_time:.6f}" 형식: 소수점 이하 정확히 6자리
         assert "." in value
@@ -150,7 +150,7 @@ class TestSanitizeCorrelationId:
 
 class TestCorrelationIdMiddleware:
     async def test_response_includes_correlation_id(self, client):
-        resp = await client.get("/api/health")
+        resp = await client.get("/api/v1/health")
         assert "x-correlation-id" in resp.headers
         import uuid
 
@@ -158,12 +158,12 @@ class TestCorrelationIdMiddleware:
 
     async def test_custom_correlation_id_passthrough(self, client):
         custom_id = "550e8400-e29b-41d4-a716-446655440000"
-        resp = await client.get("/api/health", headers={"X-Correlation-ID": custom_id})
+        resp = await client.get("/api/v1/health", headers={"X-Correlation-ID": custom_id})
         assert resp.headers["x-correlation-id"] == custom_id
 
     async def test_invalid_correlation_id_replaced(self, client):
         resp = await client.get(
-            "/api/health",
+            "/api/v1/health",
             headers={"X-Correlation-ID": "not-a-valid-uuid"},
         )
         cid = resp.headers["x-correlation-id"]
@@ -173,8 +173,8 @@ class TestCorrelationIdMiddleware:
         uuid.UUID(cid)  # should be a valid UUID
 
     async def test_different_requests_get_different_ids(self, client):
-        resp1 = await client.get("/api/health")
-        resp2 = await client.get("/api/health")
+        resp1 = await client.get("/api/v1/health")
+        resp2 = await client.get("/api/v1/health")
         assert resp1.headers["x-correlation-id"] != resp2.headers["x-correlation-id"]
 
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -66,37 +66,37 @@ def _get_op(openapi_schema, method: str, path: str) -> dict:
 
 
 def test_health_tag(openapi_schema):
-    op = _get_op(openapi_schema, "get", "/api/health")
+    op = _get_op(openapi_schema, "get", "/api/v1/health")
     assert "system" in op["tags"]
 
 
 def test_cache_stats_tag(openapi_schema):
-    op = _get_op(openapi_schema, "get", "/api/cache/stats")
+    op = _get_op(openapi_schema, "get", "/api/v1/cache/stats")
     assert "system" in op["tags"]
 
 
 def test_describe_tag(openapi_schema):
-    op = _get_op(openapi_schema, "post", "/api/describe")
+    op = _get_op(openapi_schema, "post", "/api/v1/describe")
     assert "analysis" in op["tags"]
 
 
 def test_geocode_tag(openapi_schema):
-    op = _get_op(openapi_schema, "post", "/api/geocode")
+    op = _get_op(openapi_schema, "post", "/api/v1/geocode")
     assert "data" in op["tags"]
 
 
 def test_landcover_tag(openapi_schema):
-    op = _get_op(openapi_schema, "post", "/api/landcover")
+    op = _get_op(openapi_schema, "post", "/api/v1/landcover")
     assert "data" in op["tags"]
 
 
 def test_context_tag(openapi_schema):
-    op = _get_op(openapi_schema, "post", "/api/context")
+    op = _get_op(openapi_schema, "post", "/api/v1/context")
     assert "data" in op["tags"]
 
 
 def test_descriptions_tag(openapi_schema):
-    op = _get_op(openapi_schema, "get", "/api/descriptions/{cog_image_id}")
+    op = _get_op(openapi_schema, "get", "/api/v1/descriptions/{cog_image_id}")
     assert "analysis" in op["tags"]
 
 
@@ -104,65 +104,65 @@ def test_descriptions_tag(openapi_schema):
 
 
 def test_health_summary(openapi_schema):
-    assert _get_op(openapi_schema, "get", "/api/health")["summary"]
+    assert _get_op(openapi_schema, "get", "/api/v1/health")["summary"]
 
 
 def test_describe_summary(openapi_schema):
-    assert _get_op(openapi_schema, "post", "/api/describe")["summary"]
+    assert _get_op(openapi_schema, "post", "/api/v1/describe")["summary"]
 
 
 def test_describe_description(openapi_schema):
-    op = _get_op(openapi_schema, "post", "/api/describe")
+    op = _get_op(openapi_schema, "post", "/api/v1/describe")
     assert "Gemini" in op.get("description", "")
 
 
 def test_geocode_summary(openapi_schema):
-    assert _get_op(openapi_schema, "post", "/api/geocode")["summary"]
+    assert _get_op(openapi_schema, "post", "/api/v1/geocode")["summary"]
 
 
 def test_landcover_summary(openapi_schema):
-    assert _get_op(openapi_schema, "post", "/api/landcover")["summary"]
+    assert _get_op(openapi_schema, "post", "/api/v1/landcover")["summary"]
 
 
 def test_context_summary(openapi_schema):
-    assert _get_op(openapi_schema, "post", "/api/context")["summary"]
+    assert _get_op(openapi_schema, "post", "/api/v1/context")["summary"]
 
 
 # ── 오류 응답 문서화 ───────────────────────────────────────────────────────────
 
 
 def test_describe_has_422_response(openapi_schema):
-    responses = _get_op(openapi_schema, "post", "/api/describe")["responses"]
+    responses = _get_op(openapi_schema, "post", "/api/v1/describe")["responses"]
     assert "422" in responses
 
 
 def test_describe_has_429_response(openapi_schema):
-    responses = _get_op(openapi_schema, "post", "/api/describe")["responses"]
+    responses = _get_op(openapi_schema, "post", "/api/v1/describe")["responses"]
     assert "429" in responses
 
 
 def test_descriptions_has_404_response(openapi_schema):
-    responses = _get_op(openapi_schema, "get", "/api/descriptions/{cog_image_id}")["responses"]
+    responses = _get_op(openapi_schema, "get", "/api/v1/descriptions/{cog_image_id}")["responses"]
     assert "404" in responses
 
 
 def test_geocode_has_422_response(openapi_schema):
-    responses = _get_op(openapi_schema, "post", "/api/geocode")["responses"]
+    responses = _get_op(openapi_schema, "post", "/api/v1/geocode")["responses"]
     assert "422" in responses
 
 
 def test_geocode_has_429_response(openapi_schema):
-    responses = _get_op(openapi_schema, "post", "/api/geocode")["responses"]
+    responses = _get_op(openapi_schema, "post", "/api/v1/geocode")["responses"]
     assert "429" in responses
 
 
 def test_landcover_has_422_response(openapi_schema):
-    responses = _get_op(openapi_schema, "post", "/api/landcover")["responses"]
+    responses = _get_op(openapi_schema, "post", "/api/v1/landcover")["responses"]
     assert "422" in responses
 
 
 def test_context_has_422_response(openapi_schema):
-    responses = _get_op(openapi_schema, "post", "/api/context")["responses"]
+    responses = _get_op(openapi_schema, "post", "/api/v1/context")["responses"]
     assert "422" in responses
 
 

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -85,8 +85,8 @@ class TestRateLimitMiddleware:
             "captured_at": "2025-06-15T00:00:00Z",
         }
         with patch("app.config.settings.rate_limit", "1/minute"):
-            await rate_limit_client.post("/api/describe", json=body, headers=headers)
-            resp = await rate_limit_client.post("/api/describe", json=body, headers=headers)
+            await rate_limit_client.post("/api/v1/describe", json=body, headers=headers)
+            resp = await rate_limit_client.post("/api/v1/describe", json=body, headers=headers)
             assert resp.status_code == 429
 
     async def test_429_response_body(self, rate_limit_client):
@@ -98,15 +98,15 @@ class TestRateLimitMiddleware:
             "captured_at": "2025-06-15T00:00:00Z",
         }
         with patch("app.config.settings.rate_limit", "1/minute"):
-            await rate_limit_client.post("/api/describe", json=body, headers=headers)
-            resp = await rate_limit_client.post("/api/describe", json=body, headers=headers)
+            await rate_limit_client.post("/api/v1/describe", json=body, headers=headers)
+            resp = await rate_limit_client.post("/api/v1/describe", json=body, headers=headers)
             assert resp.status_code == 429
             data = resp.json()
             assert "error" in data or "detail" in data
 
     async def test_health_endpoint_not_rate_limited(self, rate_limit_client):
         for _ in range(10):
-            resp = await rate_limit_client.get("/api/health")
+            resp = await rate_limit_client.get("/api/v1/health")
             assert resp.status_code == 200
 
     async def test_rate_limit_per_endpoint(self, rate_limit_client):
@@ -120,9 +120,9 @@ class TestRateLimitMiddleware:
         }
         with patch("app.config.settings.rate_limit", "1/minute"):
             # Exhaust describe limit
-            await rate_limit_client.post("/api/describe", json=body, headers=headers)
-            resp = await rate_limit_client.post("/api/describe", json=body, headers=headers)
+            await rate_limit_client.post("/api/v1/describe", json=body, headers=headers)
+            resp = await rate_limit_client.post("/api/v1/describe", json=body, headers=headers)
             assert resp.status_code == 429
             # cache/stats should still work (no rate limit)
-            resp = await rate_limit_client.get("/api/cache/stats")
+            resp = await rate_limit_client.get("/api/v1/cache/stats")
             assert resp.status_code == 200

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -45,7 +45,7 @@ async def shutdown_client(tmp_path, monkeypatch):
 async def test_shutdown_rejects_new_requests(shutdown_client, monkeypatch):
     """Non-system endpoints return 503 during shutdown."""
     monkeypatch.setattr(main_mod, "_shutting_down", True)
-    resp = await shutdown_client.post("/api/describe", json={})
+    resp = await shutdown_client.post("/api/v1/describe", json={})
     assert resp.status_code == 503
     assert resp.json()["detail"] == "Server is shutting down"
     assert resp.json()["status"] == 503
@@ -54,14 +54,14 @@ async def test_shutdown_rejects_new_requests(shutdown_client, monkeypatch):
 async def test_health_shows_shutting_down_status(shutdown_client, monkeypatch):
     """Health endpoint remains accessible and shows shutting_down status during shutdown."""
     monkeypatch.setattr(main_mod, "_shutting_down", True)
-    resp = await shutdown_client.get("/api/health")
+    resp = await shutdown_client.get("/api/v1/health")
     assert resp.status_code == 503
     body = resp.json()
     assert body["status"] == "shutting_down"
 
 
 async def test_normal_requests_pass_when_not_shutting_down(shutdown_client):
-    resp = await shutdown_client.get("/api/health")
+    resp = await shutdown_client.get("/api/v1/health")
     assert resp.status_code == 200
     data = resp.json()
     assert data["status"] == "ok"
@@ -70,7 +70,7 @@ async def test_normal_requests_pass_when_not_shutting_down(shutdown_client):
 async def test_in_flight_counter_tracks_requests(shutdown_client):
     """In-flight counter increments and decrements around requests."""
     assert main_mod._in_flight == 0
-    resp = await shutdown_client.get("/api/health")
+    resp = await shutdown_client.get("/api/v1/health")
     assert resp.status_code == 200
     assert main_mod._in_flight == 0
 

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -36,7 +36,7 @@ async def test_timeout_returns_504(timeout_client, monkeypatch):
     monkeypatch.setattr(routes_mod, "compose_description", _slow_compose)
 
     resp = await timeout_client.post(
-        "/api/describe",
+        "/api/v1/describe",
         json={
             "coordinates": [127.0, 37.0],
             "thumbnail": "dGVzdA==",
@@ -48,7 +48,7 @@ async def test_timeout_returns_504(timeout_client, monkeypatch):
 
 
 async def test_system_endpoints_skip_timeout(timeout_client):
-    resp = await timeout_client.get("/api/health")
+    resp = await timeout_client.get("/api/v1/health")
     assert resp.status_code == 200
 
 
@@ -60,5 +60,5 @@ async def test_normal_request_not_affected(timeout_client, monkeypatch):
 
     monkeypatch.setattr(supabase_mod, "ping", _ok)
 
-    resp = await timeout_client.get("/api/health")
+    resp = await timeout_client.get("/api/v1/health")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- `/api/` → `/api/v1/` 라우터 prefix 변경으로 API 버전 관리 도입
- `/api/*` 레거시 경로는 `/api/v1/*`로 307 Temporary Redirect하여 하위 호환성 유지
- Dockerfile HEALTHCHECK, 로깅 skip paths, 전체 테스트 코드 경로 업데이트

closes #167

## Test plan
- [x] 전체 테스트 372건 통과 (3 skipped)
- [x] 레거시 리다이렉트 테스트 4건 추가 (GET/POST/DELETE/쿼리파라미터 보존)
- [x] OpenAPI 경로 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)