### PR TITLE
chore: Docker HEALTHCHECK v1 경로 반영

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - cache-data:/tmp/cache
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/api/health')"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/api/v1/health')"]
       interval: 30s
       timeout: 5s
       start_period: 10s


### PR DESCRIPTION
## Summary
- docker-compose.yml healthcheck 경로를 `/api/health` → `/api/v1/health`로 업데이트
- Dockerfile은 이미 v1 경로 사용 중이었으나 docker-compose.yml만 누락되어 정합성 수정

## Test plan
- [x] docker-compose.yml healthcheck 경로가 Dockerfile과 일치하는지 확인
- [x] 기존 테스트 스위트 전체 통과

closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)