### PR TITLE
fix: app/api/routes.py lint 오류 수정 (I001, E501)

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -26,11 +26,10 @@ from app.api.schemas import (
     Warning,
 )
 from app.auth import authenticate
-from app.utils.errors import ProblemDetail
 from app.config import settings
 from app.db import supabase as db
 from app.services.composer import compose_description, get_breaker_statuses
-from app.utils.errors import DescriptorError
+from app.utils.errors import DescriptorError, ProblemDetail
 from app.utils.rate_limit import get_real_ip
 from app.utils.timeout import apply_timeout
 
@@ -306,7 +305,10 @@ async def context_endpoint(
     response_model=DescriptionListResponse,
     tags=["analysis"],
     summary="설명 이력 목록 조회",
-    description="저장된 설명 목록을 페이지네이션으로 조회합니다. offset/limit으로 페이지 이동이 가능합니다.",
+    description=(
+        "저장된 설명 목록을 페이지네이션으로 조회합니다. "
+        "offset/limit으로 페이지 이동이 가능합니다."
+    ),
     responses={
         422: {"model": ErrorResponse, "description": "유효하지 않은 쿼리 파라미터"},
         429: {"description": "요청 횟수 초과"},
@@ -373,7 +375,10 @@ async def get_description(
     status_code=204,
     tags=["analysis"],
     summary="설명 삭제",
-    description="cog_image_id로 저장된 분석 결과를 삭제합니다. 성공 시 204 No Content를 반환합니다.",
+    description=(
+        "cog_image_id로 저장된 분석 결과를 삭제합니다. "
+        "성공 시 204 No Content를 반환합니다."
+    ),
     responses={
         404: {"model": ProblemDetail, "description": "해당 ID의 설명을 찾을 수 없음"},
         429: {"description": "요청 횟수 초과"},


### PR DESCRIPTION
## Summary
- import 정렬 순서 수정 및 중복 import(`app.utils.errors`) 병합 (I001)
- 라인 길이 초과 2건 문자열 분할로 수정 (E501)

closes #181

## Test plan
- [x] `ruff check app/api/routes.py` 통과 확인
- [x] `pytest tests/ -x -q` 전체 테스트 통과 (417 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)