### PR TITLE
docs: GZip 미들웨어, Docker healthcheck, 보안 테스트 CHANGELOG 문서화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API 버전 관리 도입: 모든 엔드포인트가 `/api/v1/` prefix를 사용. 레거시 `/api/*` 경로는 `/api/v1/*`으로 307 영구 리다이렉트하여 하위 호환성 유지
 - 엔드포인트별 Rate Limiting 세분화: describe(20/min), batch(10/min), data(30/min), read(60/min). 환경변수(`RATE_LIMIT_DESCRIBE`, `RATE_LIMIT_BATCH`, `RATE_LIMIT_DATA`, `RATE_LIMIT_READ`)로 외부 설정 가능
 - Rate Limit 초과 시 RFC 7807 형식 에러 응답 + RFC 7231 준수 `Retry-After` 헤더(초 단위 정수) 반환
+- GZip 응답 압축 미들웨어 추가: `Accept-Encoding: gzip` 요청 시 응답 자동 압축. `GZIP_MIN_SIZE` 환경변수로 최소 압축 크기 설정 가능 (기본값: 500 bytes)
+
+### Fixed
+
+- docker-compose.yml healthcheck 경로를 `/api/health` → `/api/v1/health`로 수정하여 Dockerfile과 정합성 일치
+
+### Security
+
+- OWASP 기반 보안 네거티브 테스트 28건 추가: 비정상 좌표값, 과도한 입력, 잘못된 Content-Type, 인증 우회 시도, 보안 헤더 검증 포함
 
 ## [0.24.0] - 2026-03-07
 


### PR DESCRIPTION
## Summary

- PR #179 (GZip 응답 압축 미들웨어): `[Unreleased] Added` 항목 추가
- PR #176 (Docker HEALTHCHECK v1 경로): `[Unreleased] Fixed` 항목 추가
- PR #180 (OWASP 보안 네거티브 테스트): `[Unreleased] Security` 항목 추가

마지막 문서화 PR(#172) 이후 머지된 기능/수정 사항을 CHANGELOG에 반영합니다.
테스트 전용 PR(#175)은 공개 API 변경 없으므로 CHANGELOG 미기재.

## Test plan
- [x] CHANGELOG `[Unreleased]` 섹션에 3개 항목 추가 확인
- [x] Keep a Changelog 형식 준수 (Added/Fixed/Security 분류)

🤖 Generated with [Claude Code](https://claude.com/claude-code)