### PR TITLE
feat: OpenTelemetry trace context 전파 및 구조화 로깅 강화

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -32,6 +32,8 @@ class Settings(BaseSettings):
     cache_ttl_seconds: int = 86400 * 30  # 30 days default
     cache_cleanup_interval_seconds: int = 3600
     gzip_min_size: int = 500
+    service_name: str = "image-descriptor"
+    environment: str = "production"
 
     @field_validator(
         "cache_ttl_seconds",

--- a/app/utils/logging.py
+++ b/app/utils/logging.py
@@ -9,6 +9,9 @@ from starlette.requests import Request
 from app.config import settings
 
 _VALID_REQUEST_ID = re.compile(r"^[\w\-]{1,128}$")
+_TRACEPARENT_RE = re.compile(
+    r"^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$"
+)
 
 _SENSITIVE_HEADERS = frozenset(
     {
@@ -45,6 +48,7 @@ def setup_logging() -> None:
         structlog.processors.TimeStamper(fmt="iso"),
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,
+        _add_service_context,
     ]
 
     structlog.configure(
@@ -92,6 +96,23 @@ def _safe_query_params(query_string: str) -> str:
     )
 
 
+def parse_traceparent(value: str | None) -> dict[str, str] | None:
+    """Parse a W3C traceparent header and return trace_id and span_id."""
+    if not value:
+        return None
+    match = _TRACEPARENT_RE.match(value.strip())
+    if not match:
+        return None
+    return {"trace_id": match.group(2), "span_id": match.group(3)}
+
+
+def _add_service_context(logger, method_name, event_dict):
+    """Structlog processor that adds service_name and environment."""
+    event_dict["service_name"] = settings.service_name
+    event_dict["environment"] = settings.environment
+    return event_dict
+
+
 def _sanitize_correlation_id(value: str | None) -> str | None:
     """Validate a client-provided correlation ID (UUID format)."""
     if not value:
@@ -113,8 +134,16 @@ async def request_id_middleware(request: Request, call_next):
     request.state.correlation_id = correlation_id
 
     structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(request_id=request_id, correlation_id=correlation_id)
+    ctx = {"request_id": request_id, "correlation_id": correlation_id}
 
+    trace_ctx = parse_traceparent(request.headers.get("traceparent"))
+    if trace_ctx:
+        ctx["trace_id"] = trace_ctx["trace_id"]
+        ctx["span_id"] = trace_ctx["span_id"]
+
+    structlog.contextvars.bind_contextvars(**ctx)
+
+    client_ip = request.client.host if request.client else None
     path = request.url.path
     skip_log = path in _SKIP_LOG_PATHS
 
@@ -138,23 +167,21 @@ async def request_id_middleware(request: Request, call_next):
     response.headers["X-Correlation-ID"] = correlation_id
     response.headers["X-Process-Time"] = f"{process_time:.6f}"
 
+    response_size = int(response.headers.get("content-length", 0))
+    finish_kwargs = {
+        "method": request.method,
+        "path": path,
+        "status_code": response.status_code,
+        "latency_ms": latency_ms,
+        "response_size": response_size,
+        "client_ip": client_ip,
+    }
+
     if not skip_log:
         log_method = logger.awarning if response.status_code >= 400 else logger.ainfo
-        await log_method(
-            "request_finished",
-            method=request.method,
-            path=path,
-            status_code=response.status_code,
-            latency_ms=latency_ms,
-        )
+        await log_method("request_finished", **finish_kwargs)
     elif response.status_code >= 400:
-        await logger.awarning(
-            "request_finished",
-            method=request.method,
-            path=path,
-            status_code=response.status_code,
-            latency_ms=latency_ms,
-        )
+        await logger.awarning("request_finished", **finish_kwargs)
 
     structlog.contextvars.clear_contextvars()
     return response

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -13,6 +13,7 @@ from app.utils.logging import (
     _sanitize_request_id,
     generate_correlation_id,
     generate_request_id,
+    parse_traceparent,
     setup_logging,
 )
 
@@ -214,6 +215,73 @@ class TestSafeQueryParams:
     def test_no_sensitive_params(self):
         result = _safe_query_params("page=1&limit=10")
         assert result == "page=1&limit=10"
+
+
+class TestParseTraceparent:
+    def test_valid_traceparent(self):
+        header = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        result = parse_traceparent(header)
+        assert result == {
+            "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+            "span_id": "00f067aa0ba902b7",
+        }
+
+    def test_none_input(self):
+        assert parse_traceparent(None) is None
+
+    def test_empty_string(self):
+        assert parse_traceparent("") is None
+
+    def test_invalid_format(self):
+        assert parse_traceparent("not-a-traceparent") is None
+
+    def test_wrong_length_trace_id(self):
+        assert parse_traceparent("00-abcd-00f067aa0ba902b7-01") is None
+
+    def test_uppercase_rejected(self):
+        assert parse_traceparent("00-4BF92F3577B34DA6A3CE929D0E0E4736-00F067AA0BA902B7-01") is None
+
+    def test_whitespace_trimmed(self):
+        header = "  00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01  "
+        result = parse_traceparent(header)
+        assert result is not None
+        assert result["trace_id"] == "4bf92f3577b34da6a3ce929d0e0e4736"
+
+
+class TestTraceparentMiddleware:
+    async def test_traceparent_binds_trace_context(self, client):
+        """traceparent 헤더가 있으면 요청이 정상 처리된다."""
+        resp = await client.get(
+            "/api/v1/health",
+            headers={"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
+        )
+        assert resp.status_code == 200
+        assert "x-request-id" in resp.headers
+
+    async def test_invalid_traceparent_ignored(self, client):
+        """잘못된 traceparent 헤더는 무시되고 요청은 정상 처리된다."""
+        resp = await client.get(
+            "/api/v1/health",
+            headers={"traceparent": "invalid-value"},
+        )
+        assert resp.status_code == 200
+
+    async def test_no_traceparent_still_works(self, client):
+        """traceparent 헤더 없이도 기존 동작 유지."""
+        resp = await client.get("/api/v1/health")
+        assert resp.status_code == 200
+        assert "x-correlation-id" in resp.headers
+
+
+class TestServiceContextProcessor:
+    def test_setup_logging_includes_service_context(self, capsys):
+        """setup_logging 후 로그에 service_name과 environment가 포함된다."""
+        setup_logging()
+        logger = structlog.get_logger()
+        logger.info("test_event")
+        captured = capsys.readouterr()
+        assert "service_name" in captured.out
+        assert "environment" in captured.out
 
 
 class TestSanitizeRequestId:


### PR DESCRIPTION
## Summary
- W3C `traceparent` 헤더 파싱하여 `trace_id`, `span_id`를 structlog 컨텍스트에 바인딩
- 응답 로그에 `response_size`, `client_ip` 필드 추가로 운영 가시성 향상
- structlog 프로세서로 `service_name`, `environment` 필드 자동 삽입
- 기존 `X-Correlation-ID` 기능과 완전 공존

closes #189

## Test plan
- [x] `parse_traceparent` 유효/무효 입력 테스트 7건
- [x] traceparent 미들웨어 통합 테스트 3건
- [x] service_name/environment 프로세서 테스트 1건
- [x] 기존 테스트 36건 모두 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)