### PR TITLE
feat: pytest 커버리지 리포트 CI 연동 (#194)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run tests with coverage
-        run: uv run pytest -v --tb=short --junitxml=test-results.xml --cov=app --cov-report=xml --cov-report=term-missing
+        run: uv run pytest -v --tb=short --junitxml=test-results.xml --cov=app --cov-report=xml --cov-report=json --cov-report=term-missing --cov-fail-under=80
         env:
           GOOGLE_AI_API_KEY: "test-key"
           SUPABASE_URL: "https://test.supabase.co"
@@ -69,7 +69,9 @@ jobs:
         if: always() && matrix.python-version == '3.11'
         with:
           name: coverage-report
-          path: coverage.xml
+          path: |
+            coverage.xml
+            coverage.json
 
       - name: Coverage comment on PR
         uses: MishaKav/pytest-coverage-comment@v1.5.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # COGnito Image Descriptor
 
+[![CI](https://github.com/conaonda/ImageDescriptor/actions/workflows/ci.yml/badge.svg)](https://github.com/conaonda/ImageDescriptor/actions/workflows/ci.yml)
+![Coverage](https://img.shields.io/badge/coverage-98%25-brightgreen)
+
 위성영상 좌표 기반 설명 생성 서비스. 좌표와 썸네일을 입력받아 위치 정보, 토지피복, 주변 맥락을 조합해 자연어 설명을 생성한다.
 
 ## 빠른 시작

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ markers = ["e2e: end-to-end test requiring real API keys (.env)"]
 source = ["app"]
 
 [tool.coverage.report]
-fail_under = 50
+fail_under = 80
 show_missing = true
 exclude_lines = [
     "pragma: no cover",


### PR DESCRIPTION
## Summary
- 커버리지 임계값을 50%에서 80%로 상향하여 미달 시 CI 실패 처리
- CI에서 `coverage.json` 아티팩트 추가 저장
- README에 CI 상태 및 커버리지 뱃지 추가

## 변경 파일
- `.github/workflows/ci.yml`: `--cov-fail-under=80`, `--cov-report=json` 추가, 아티팩트에 `coverage.json` 포함
- `pyproject.toml`: `fail_under = 80`으로 변경
- `README.md`: CI/커버리지 뱃지 추가

## Test plan
- [x] `pytest --cov-fail-under=80` 로컬 테스트 통과 확인 (현재 98%)
- [ ] CI workflow에서 커버리지 리포트 정상 생성 확인
- [ ] PR 코멘트에 커버리지 리포트 표시 확인

closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)