### PR TITLE
feat: README 커버리지 뱃지 Codecov 동적 갱신 (#197)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,13 @@ jobs:
             coverage.xml
             coverage.json
 
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        if: matrix.python-version == '3.11'
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false
+
       - name: Coverage comment on PR
         uses: MishaKav/pytest-coverage-comment@v1.5.0
         if: github.event_name == 'pull_request' && matrix.python-version == '3.11'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # COGnito Image Descriptor
 
 [![CI](https://github.com/conaonda/ImageDescriptor/actions/workflows/ci.yml/badge.svg)](https://github.com/conaonda/ImageDescriptor/actions/workflows/ci.yml)
-![Coverage](https://img.shields.io/badge/coverage-98%25-brightgreen)
+[![codecov](https://codecov.io/gh/conaonda/ImageDescriptor/graph/badge.svg)](https://codecov.io/gh/conaonda/ImageDescriptor)
 
 위성영상 좌표 기반 설명 생성 서비스. 좌표와 썸네일을 입력받아 위치 정보, 토지피복, 주변 맥락을 조합해 자연어 설명을 생성한다.
 


### PR DESCRIPTION
## Summary
- 정적 하드코딩된 커버리지 뱃지(`98%`)를 Codecov 동적 뱃지로 교체
- CI 워크플로우에 `codecov/codecov-action@v5` 업로드 스텝 추가 (Python 3.11 매트릭스에서만 실행)
- 커버리지 변동 시 README 뱃지가 자동으로 갱신됨

## Test plan
- [x] 기존 테스트 전체 통과 확인 (457 passed)
- [ ] Codecov GitHub App 설치 후 뱃지 정상 표시 확인
- [ ] PR merge 후 main 브랜치 CI에서 Codecov 업로드 확인

closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)