### PR TITLE
fix: CI pip-audit 인자 오류 및 lint 수정 (#212)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,11 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run pip-audit
-        run: uv run pip-audit --require-hashes=false --progress-spinner=off --desc -f json -o audit-results.json || true
+        run: uv run pip-audit --no-require-hashes --progress-spinner=off --desc -f json -o audit-results.json || true
 
       - name: Check audit results
         run: |
-          if uv run pip-audit --require-hashes=false --progress-spinner=off --desc; then
+          if uv run pip-audit --no-require-hashes --progress-spinner=off --desc; then
             echo "No vulnerabilities found."
           else
             echo "::error::Security vulnerabilities found in dependencies!"

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -21,8 +21,8 @@ from app.api.schemas import (
     DescriptionListResponse,
     ErrorResponse,  # kept for backward compat
     HealthResponse,
-    LiveResponse,
     LandCover,
+    LiveResponse,
     Location,
     Warning,
 )
@@ -252,7 +252,12 @@ async def describe_batch(
         for i, item in enumerate(body.items):
             if is_shutting_down():
                 for j in range(i, len(body.items)):
-                    results.append(BatchItemResult(index=j, error="interrupted: server shutting down"))
+                    results.append(
+                        BatchItemResult(
+                            index=j,
+                            error="interrupted: server shutting down",
+                        )
+                    )
                 logger.warning(
                     "batch_interrupted_by_shutdown",
                     completed=i,
@@ -360,8 +365,7 @@ async def context_endpoint(
     tags=["analysis"],
     summary="설명 이력 목록 조회",
     description=(
-        "저장된 설명 목록을 페이지네이션으로 조회합니다. "
-        "offset/limit으로 페이지 이동이 가능합니다."
+        "저장된 설명 목록을 페이지네이션으로 조회합니다. offset/limit으로 페이지 이동이 가능합니다."
     ),
     responses={
         422: {"model": ErrorResponse, "description": "유효하지 않은 쿼리 파라미터"},
@@ -430,8 +434,7 @@ async def get_description(
     tags=["analysis"],
     summary="설명 삭제",
     description=(
-        "cog_image_id로 저장된 분석 결과를 삭제합니다. "
-        "성공 시 204 No Content를 반환합니다."
+        "cog_image_id로 저장된 분석 결과를 삭제합니다. 성공 시 204 No Content를 반환합니다."
     ),
     responses={
         404: {"model": ProblemDetail, "description": "해당 ID의 설명을 찾을 수 없음"},


### PR DESCRIPTION
## Summary
- `pip-audit --require-hashes=false` → `--no-require-hashes`로 변경하여 인자 파싱 오류 해결
- `app/api/routes.py` import 정렬(I001) 및 라인 길이(E501) lint 오류 수정

## Test plan
- [x] `ruff check` 통과 확인
- [x] `pytest` 472 passed, 3 skipped

closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)