### PR TITLE
fix(cache,retry,db): 에러 핸들링 강화 (#219, #220, #221)

### DIFF
--- a/app/cache/store.py
+++ b/app/cache/store.py
@@ -6,7 +6,7 @@ import aiosqlite
 import structlog
 
 from app.cache.migrator import run_migrations
-from app.utils.metrics import cache_cleanup_total, cache_hits, cache_misses
+from app.utils.metrics import cache_cleanup_total, cache_errors, cache_hits, cache_misses
 
 logger = structlog.get_logger()
 
@@ -27,18 +27,27 @@ class CacheStore:
 
     async def get(self, key: str) -> dict | None:
         module = self._module_from_key(key)
-        async with self._db.execute(
-            "SELECT value, expires_at FROM cache WHERE key = ?", (key,)
-        ) as cursor:
-            row = await cursor.fetchone()
+        try:
+            async with self._db.execute(
+                "SELECT value, expires_at FROM cache WHERE key = ?", (key,)
+            ) as cursor:
+                row = await cursor.fetchone()
+        except Exception as e:
+            logger.warning("cache_get_error", key=key, error=str(e))
+            cache_errors.labels(operation="get").inc()
+            return None
         if row is None:
             self._misses[module] += 1
             cache_misses.labels(module=module).inc()
             return None
         value, expires_at = row
         if expires_at and time.time() > expires_at:
-            await self._db.execute("DELETE FROM cache WHERE key = ?", (key,))
-            await self._db.commit()
+            try:
+                await self._db.execute("DELETE FROM cache WHERE key = ?", (key,))
+                await self._db.commit()
+            except Exception as e:
+                logger.warning("cache_expire_delete_error", key=key, error=str(e))
+                cache_errors.labels(operation="delete").inc()
             self._misses[module] += 1
             cache_misses.labels(module=module).inc()
             return None
@@ -59,11 +68,15 @@ class CacheStore:
             expires_at = time.time() + ttl_days * 86400
         else:
             expires_at = None
-        await self._db.execute(
-            "INSERT OR REPLACE INTO cache (key, value, expires_at) VALUES (?, ?, ?)",
-            (key, json.dumps(value, ensure_ascii=False), expires_at),
-        )
-        await self._db.commit()
+        try:
+            await self._db.execute(
+                "INSERT OR REPLACE INTO cache (key, value, expires_at) VALUES (?, ?, ?)",
+                (key, json.dumps(value, ensure_ascii=False), expires_at),
+            )
+            await self._db.commit()
+        except Exception as e:
+            logger.warning("cache_set_error", key=key, error=str(e))
+            cache_errors.labels(operation="set").inc()
 
     async def stats(self) -> dict:
         async with self._db.execute("SELECT COUNT(*) FROM cache") as cursor:
@@ -102,11 +115,16 @@ class CacheStore:
 
     async def cleanup_expired(self) -> int:
         now = time.time()
-        async with self._db.execute(
-            "DELETE FROM cache WHERE expires_at IS NOT NULL AND expires_at < ?", (now,)
-        ) as cursor:
-            deleted = cursor.rowcount
-        await self._db.commit()
+        try:
+            async with self._db.execute(
+                "DELETE FROM cache WHERE expires_at IS NOT NULL AND expires_at < ?", (now,)
+            ) as cursor:
+                deleted = cursor.rowcount
+            await self._db.commit()
+        except Exception as e:
+            logger.warning("cache_cleanup_error", error=str(e))
+            cache_errors.labels(operation="cleanup").inc()
+            return 0
         if deleted > 0:
             cache_cleanup_total.inc(deleted)
             logger.info("cache_cleanup", deleted=deleted)

--- a/app/db/supabase.py
+++ b/app/db/supabase.py
@@ -99,14 +99,21 @@ async def list_descriptions(
 
 
 async def delete_description(cog_image_id: str) -> bool:
-    client = await get_client()
-    result = (
-        await client.table("image_descriptions").delete().eq("cog_image_id", cog_image_id).execute()
-    )
-    if not result.data:
+    try:
+        client = await get_client()
+        result = (
+            await client.table("image_descriptions")
+            .delete()
+            .eq("cog_image_id", cog_image_id)
+            .execute()
+        )
+        if not result.data:
+            return False
+        logger.info("deleted description from supabase", cog_image_id=cog_image_id)
+        return True
+    except Exception as e:
+        logger.error("supabase delete failed", cog_image_id=cog_image_id, error=str(e))
         return False
-    logger.info("deleted description from supabase", cog_image_id=cog_image_id)
-    return True
 
 
 async def get_description(cog_image_id: str) -> dict | None:

--- a/app/utils/metrics.py
+++ b/app/utils/metrics.py
@@ -40,6 +40,12 @@ cache_cleanup_total = Counter(
     "Total expired cache entries removed",
 )
 
+cache_errors = Counter(
+    "cache_errors_total",
+    "Total cache operation errors",
+    ["operation"],
+)
+
 # Circuit breaker metrics (0=closed, 1=open, 2=half-open)
 circuit_breaker_state = Gauge(
     "circuit_breaker_state",

--- a/app/utils/retry.py
+++ b/app/utils/retry.py
@@ -2,6 +2,7 @@
 
 import httpx
 import structlog
+from google.genai.errors import ClientError
 from tenacity import (
     RetryCallState,
     retry,
@@ -54,8 +55,17 @@ retry_http = retry(
     reraise=True,
 )
 
+
+def _is_retryable_gemini(exc: BaseException) -> bool:
+    """Return True for transient Gemini errors. ClientError (4xx) is not retryable."""
+    if isinstance(exc, ClientError):
+        return False
+    return True
+
+
 # Gemini API: 3 attempts, 2-8s exponential backoff (slower service, longer waits)
 retry_gemini = retry(
+    retry=retry_if_exception(_is_retryable_gemini),
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=2, min=2, max=8),
     before_sleep=_log_retry,

--- a/tests/test_cache_errors.py
+++ b/tests/test_cache_errors.py
@@ -1,0 +1,31 @@
+"""Tests for cache error handling — SQLite failures should not propagate."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.cache.store import CacheStore
+
+
+@pytest.fixture
+async def cache(tmp_path):
+    store = CacheStore(str(tmp_path / "cache.db"))
+    await store.init()
+    yield store
+    await store.close()
+
+
+class TestCacheErrorHandling:
+    async def test_get_returns_none_on_sqlite_error(self, cache):
+        cache._db.execute = AsyncMock(side_effect=Exception("disk I/O error"))
+        result = await cache.get("geocode:1:2")
+        assert result is None
+
+    async def test_set_does_not_raise_on_sqlite_error(self, cache):
+        cache._db.execute = AsyncMock(side_effect=Exception("disk full"))
+        await cache.set("geocode:1:2", {"data": "test"})
+
+    async def test_cleanup_returns_zero_on_sqlite_error(self, cache):
+        cache._db.execute = AsyncMock(side_effect=Exception("locked"))
+        result = await cache.cleanup_expired()
+        assert result == 0

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -4,8 +4,9 @@ from unittest.mock import MagicMock
 
 import httpx
 import pytest
+from google.genai.errors import ClientError, ServerError
 
-from app.utils.retry import _is_retryable, retry_gemini, retry_http
+from app.utils.retry import _is_retryable, _is_retryable_gemini, retry_gemini, retry_http
 
 
 class TestIsRetryable:
@@ -120,8 +121,25 @@ class TestRetryHttp:
         assert call_count == 2
 
 
+class TestIsRetryableGemini:
+    def test_client_error_not_retryable(self):
+        exc = ClientError(400, "bad request")
+        assert not _is_retryable_gemini(exc)
+
+    def test_client_error_403_not_retryable(self):
+        exc = ClientError(403, "forbidden")
+        assert not _is_retryable_gemini(exc)
+
+    def test_server_error_is_retryable(self):
+        exc = ServerError(500, "internal error")
+        assert _is_retryable_gemini(exc)
+
+    def test_runtime_error_is_retryable(self):
+        assert _is_retryable_gemini(RuntimeError("transient"))
+
+
 class TestRetryGemini:
-    async def test_retries_any_exception(self):
+    async def test_retries_transient_exception(self):
         call_count = 0
 
         @retry_gemini
@@ -148,3 +166,16 @@ class TestRetryGemini:
         with pytest.raises(RuntimeError):
             await call_api()
         assert call_count == 3
+
+    async def test_no_retry_on_client_error(self):
+        call_count = 0
+
+        @retry_gemini
+        async def call_api():
+            nonlocal call_count
+            call_count += 1
+            raise ClientError(400, "invalid argument")
+
+        with pytest.raises(ClientError):
+            await call_api()
+        assert call_count == 1

--- a/tests/test_supabase.py
+++ b/tests/test_supabase.py
@@ -211,7 +211,7 @@ class TestDeleteDescription:
         ):
             assert await db_module.delete_description("nonexistent") is False
 
-    async def test_delete_raises_on_error(self):
+    async def test_delete_returns_false_on_error(self):
         mock_client = MagicMock()
         mock_client.table.return_value.delete.return_value.eq.return_value.execute = AsyncMock(
             side_effect=Exception("db error")
@@ -219,8 +219,7 @@ class TestDeleteDescription:
         with patch.object(
             db_module, "get_client", new_callable=AsyncMock, return_value=mock_client
         ):
-            with pytest.raises(Exception, match="db error"):
-                await db_module.delete_description("img-1")
+            assert await db_module.delete_description("img-1") is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- **#219**: SQLite 캐시 get/set/cleanup 작업에서 예외를 catch하고 경고 로그 + `cache_errors_total` Prometheus 메트릭 카운터 추가. 캐시 실패가 메인 요청을 중단시키지 않음
- **#220**: Gemini `retry_gemini`에 `retry_if_exception` 필터 추가. `ClientError`(4xx: 400, 403, 404 등) 비일시적 에러는 재시도 없이 즉시 실패
- **#221**: `delete_description()`에 try/except 추가하여 다른 DB 함수와 동일한 에러 처리 패턴 적용

closes #219
closes #220
closes #221

## Test plan
- [x] `test_cache_errors.py` — 캐시 get/set/cleanup SQLite 에러 시 graceful 처리 확인
- [x] `test_retry.py` — Gemini ClientError 재시도 안 함, ServerError/RuntimeError 재시도 확인
- [x] `test_supabase.py` — delete_description 에러 시 False 반환 확인
- [x] 전체 491 tests passed, lint/format 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)