### PR TITLE
docs: Sprint 55 문서 갱신 (입력 검증, 타임아웃 외부화)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- 입력 검증 강화 (#229): `captured_at` 필드에 ISO 8601 정규식·파싱 이중 검증 적용. `cog_image_id` 최대 128자 길이 제한 추가. `DescribeRequest` 및 `BatchDescribeItem` 모두 적용
+- 모듈별 타임아웃 외부화 (#231): `TIMEOUT_GEOCODER`(기본 10초), `TIMEOUT_LANDCOVER`(15초), `TIMEOUT_CONTEXT`(10초), `TIMEOUT_DESCRIBER`(10초), `TIMEOUT_HTTP_CLIENT`(10초) 환경변수 추가. Settings 값을 각 모듈에서 직접 참조
+
+### Fixed
+
+- 캐시 정리 루프 예외 로깅 추가 (#230): `_cache_cleanup_loop`에서 예외 발생 시 `logger.warning` 출력. rate limit 헤더 주입 예외를 구체적 타입(`ValueError`)으로 처리
+
+---
+
 - API 버전 관리 도입: 모든 엔드포인트가 `/api/v1/` prefix를 사용. 레거시 `/api/*` 경로는 `/api/v1/*`으로 307 영구 리다이렉트하여 하위 호환성 유지
 - 엔드포인트별 Rate Limiting 세분화: describe(20/min), batch(10/min), data(30/min), read(60/min). 환경변수(`RATE_LIMIT_DESCRIBE`, `RATE_LIMIT_BATCH`, `RATE_LIMIT_DATA`, `RATE_LIMIT_READ`)로 외부 설정 가능
 - Rate Limit 초과 시 RFC 7807 형식 에러 응답 + RFC 7231 준수 `Retry-After` 헤더(초 단위 정수) 반환

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -73,6 +73,16 @@ curl -X POST https://cognito-descriptor-gdno3pyjba-an.a.run.app/api/describe \
 }
 ```
 
+### 필드 검증 규칙
+
+| 필드 | 타입 | 제약 |
+|------|------|------|
+| `thumbnail` | string | base64 최대 5MB, URL은 `http(s)://` 시작 |
+| `coordinates` | [lon, lat] | 경도 −180~180, 위도 −90~90 |
+| `captured_at` | string \| null | ISO 8601 형식 (`2025-06-15` 또는 `2025-06-15T10:30:00Z`) |
+| `cog_image_id` | string \| null | 최대 128자 |
+| `bbox` | [W, S, E, N] \| null | 각각 경도/위도 범위, west < east, south < north |
+
 ## 에러 응답 형식
 
 모든 에러 응답은 [RFC 7807 Problem Details](https://datatracker.ietf.org/doc/html/rfc7807) 표준을 따르며 `Content-Type: application/problem+json`으로 반환됩니다.
@@ -120,7 +130,25 @@ curl -X POST https://cognito-descriptor-gdno3pyjba-an.a.run.app/api/describe \
 
 ## Rate Limit
 
-- POST 엔드포인트: 10 requests/minute (IP 기준)
-- GET /descriptions, DELETE /descriptions/{id}: 30 requests/minute (IP 기준)
-- 초과 시 `429 Too Many Requests` 응답
+| 엔드포인트 | 기본값 | 환경변수 |
+|-----------|--------|---------|
+| describe | 20/minute | `RATE_LIMIT_DESCRIBE` |
+| batch | 10/minute | `RATE_LIMIT_BATCH` |
+| data(GET/DELETE) | 30/minute | `RATE_LIMIT_DATA` |
+| read(GET list) | 60/minute | `RATE_LIMIT_READ` |
+| 기타 | 30/minute | `RATE_LIMIT` |
+
+- 초과 시 `429 Too Many Requests` 응답 + `Retry-After` 헤더(초 단위)
 - Cloud Run 환경에서는 `X-Forwarded-For` 헤더의 첫 번째 IP를 사용
+
+## 모듈별 타임아웃 설정
+
+각 모듈의 타임아웃을 환경변수로 개별 설정할 수 있습니다.
+
+| 환경변수 | 기본값 | 설명 |
+|---------|--------|------|
+| `TIMEOUT_GEOCODER` | 10.0 | 역지오코딩 요청 타임아웃 (초) |
+| `TIMEOUT_LANDCOVER` | 15.0 | 토지피복 조회 타임아웃 (초) |
+| `TIMEOUT_CONTEXT` | 10.0 | 맥락 정보 조회 타임아웃 (초) |
+| `TIMEOUT_DESCRIBER` | 10.0 | Gemini 설명 생성 타임아웃 (초) |
+| `TIMEOUT_HTTP_CLIENT` | 10.0 | HTTP 클라이언트 기본 타임아웃 (초) |


### PR DESCRIPTION
## Summary
- CHANGELOG.md Unreleased 섹션에 Sprint 55 변경사항 추가 (#229, #230, #231)
- integration-guide.md에 필드 검증 규칙 표, Rate Limit 테이블, 모듈별 타임아웃 환경변수 섹션 추가

## Changes
- `captured_at` ISO 8601 검증, `cog_image_id` 128자 제한 문서화
- 엔드포인트별 Rate Limit 환경변수(`RATE_LIMIT_DESCRIBE` 등) 명시
- 모듈별 타임아웃 환경변수 5개(`TIMEOUT_GEOCODER` 등) 표로 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)