### PR TITLE
fix(geocoder,landcover,mission,describer): JSON 파싱 예외 처리, 타임아웃·제한값 외부화 (#239, #240, #241)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -39,7 +39,10 @@ class Settings(BaseSettings):
     timeout_landcover: float = 15.0
     timeout_context: float = 10.0
     timeout_describer: float = 10.0
+    timeout_mission: float = 10.0
     timeout_http_client: float = 10.0
+    max_image_download_bytes: int = 5 * 1024 * 1024
+    max_image_redirects: int = 5
 
     @field_validator(
         "cache_ttl_seconds",
@@ -54,7 +57,10 @@ class Settings(BaseSettings):
         "timeout_landcover",
         "timeout_context",
         "timeout_describer",
+        "timeout_mission",
         "timeout_http_client",
+        "max_image_download_bytes",
+        "max_image_redirects",
     )
     @classmethod
     def _positive_int(cls, v: int | float, info) -> int | float:
@@ -128,7 +134,10 @@ class Settings(BaseSettings):
             timeout_landcover=self.timeout_landcover,
             timeout_context=self.timeout_context,
             timeout_describer=self.timeout_describer,
+            timeout_mission=self.timeout_mission,
             timeout_http_client=self.timeout_http_client,
+            max_image_download_bytes=self.max_image_download_bytes,
+            max_image_redirects=self.max_image_redirects,
         )
 
     model_config = {"env_file": ".env"}

--- a/app/modules/describer.py
+++ b/app/modules/describer.py
@@ -107,8 +107,8 @@ def _make_prompt(
 
 @retry_http
 async def _download_image(url: str) -> bytes:
-    max_download = 5 * 1024 * 1024
-    max_redirects = 5
+    max_download = settings.max_image_download_bytes
+    max_redirects = settings.max_image_redirects
 
     from app.http_client import get_client
 

--- a/app/modules/geocoder.py
+++ b/app/modules/geocoder.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import re
 
 import httpx
@@ -61,7 +62,19 @@ async def geocode(lon: float, lat: float, cache: CacheStore) -> Location:
         resp = await _fetch_nominatim(lon, lat)
         _last_request_time = asyncio.get_event_loop().time()
 
-    data = resp.json()
+    try:
+        data = resp.json()
+    except json.JSONDecodeError:
+        logger.warning("geocoder invalid JSON response", lon=lon, lat=lat, body=resp.text[:200])
+        return Location(
+            country="Unknown",
+            country_code="",
+            region="",
+            city=None,
+            place_name="",
+            lat=lat,
+            lon=lon,
+        )
     address = data.get("address", {})
 
     location = Location(

--- a/app/modules/landcover.py
+++ b/app/modules/landcover.py
@@ -1,3 +1,5 @@
+import json
+
 import httpx
 import structlog
 
@@ -82,7 +84,11 @@ out tags;
 
     resp = await _fetch_overpass(query)
 
-    elements = resp.json().get("elements", [])
+    try:
+        elements = resp.json().get("elements", [])
+    except json.JSONDecodeError:
+        logger.warning("landcover invalid JSON response", lon=lon, lat=lat, body=resp.text[:200])
+        return LandCover(classes=[], summary="정보 없음")
 
     # 태그 카운트 집계
     tag_counts: dict[str, int] = {}

--- a/app/modules/mission.py
+++ b/app/modules/mission.py
@@ -1,8 +1,11 @@
+import json
+
 import httpx
 import structlog
 
 from app.api.schemas import Mission
 from app.cache.store import CacheStore
+from app.config import settings
 from app.http_client import get_client
 from app.utils.retry import retry_http
 
@@ -22,7 +25,7 @@ async def _fetch_stac_item(stac_id: str) -> httpx.Response:
     collection = _guess_collection(stac_id)
     url = f"{STAC_BASE_URL}/collections/{collection}/items/{stac_id}"
     client = get_client()
-    resp = await client.get(url, timeout=10.0)
+    resp = await client.get(url, timeout=settings.timeout_mission)
     resp.raise_for_status()
     return resp
 
@@ -71,7 +74,11 @@ async def get_mission_metadata(stac_id: str | None, cache: CacheStore) -> Missio
         return Mission(**cached)
 
     resp = await _fetch_stac_item(stac_id)
-    data = resp.json()
+    try:
+        data = resp.json()
+    except json.JSONDecodeError:
+        logger.warning("mission invalid JSON response", stac_id=stac_id, body=resp.text[:200])
+        return None
     mission_dict = _parse_mission(data)
 
     await cache.set(cache_key, mission_dict, ttl_days=365)

--- a/tests/test_describer.py
+++ b/tests/test_describer.py
@@ -295,3 +295,20 @@ class TestBase64Validation:
                 land_cover_summary="주거지역",
                 cache=cache,
             )
+
+
+class TestDescriberSettings:
+    """Tests for #241: Describer 이미지 다운로드 제한값 설정 외부화."""
+
+    async def test_download_uses_settings_max_bytes(self, httpx_mock):
+        """settings.max_image_download_bytes가 _download_image에서 사용되는지 확인."""
+        from app.config import settings
+
+        large_content = b"x" * (settings.max_image_download_bytes + 1)
+        httpx_mock.add_response(
+            url="https://example.com/large.jpg",
+            headers={"content-length": str(len(large_content))},
+            content=large_content,
+        )
+        with pytest.raises(ValueError, match="Image too large"):
+            await _download_image("https://example.com/large.jpg")

--- a/tests/test_geocoder.py
+++ b/tests/test_geocoder.py
@@ -77,3 +77,17 @@ async def test_geocode_uses_settings_cache_ttl(cache, httpx_mock):
         f"cache_ttl_seconds({settings.cache_ttl_seconds})가 사용되어야 하지만 "
         f"ttl_seconds={kwargs.get('ttl_seconds')}가 전달되었습니다"
     )
+
+
+async def test_geocode_invalid_json_response(cache, httpx_mock):
+    """#239: 외부 API가 비정상 JSON을 반환하면 graceful fallback."""
+    httpx_mock.add_response(
+        url="https://nominatim.openstreetmap.org/reverse?lat=37.566&lon=126.978&format=jsonv2&accept-language=ko&zoom=8",
+        text="<html>Error</html>",
+        headers={"content-type": "text/html"},
+    )
+
+    result = await geocode(126.978, 37.566, cache)
+    assert result.country == "Unknown"
+    assert result.lat == 37.566
+    assert result.lon == 126.978

--- a/tests/test_landcover.py
+++ b/tests/test_landcover.py
@@ -58,3 +58,15 @@ async def test_landcover_uses_settings_cache_ttl(cache, httpx_mock):
         f"cache_ttl_seconds({settings.cache_ttl_seconds})가 사용되어야 하지만 "
         f"ttl_seconds={kwargs.get('ttl_seconds')}가 전달되었습니다"
     )
+
+
+async def test_land_cover_invalid_json_response(cache, httpx_mock):
+    """#239: 외부 API가 비정상 JSON을 반환하면 graceful fallback."""
+    httpx_mock.add_response(
+        text="<html>502 Bad Gateway</html>",
+        headers={"content-type": "text/html"},
+    )
+
+    result = await get_land_cover(126.978, 37.566, cache)
+    assert len(result.classes) == 0
+    assert result.summary == "정보 없음"

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -110,3 +110,24 @@ async def test_get_mission_metadata_http_error(cache, httpx_mock):
     httpx_mock.add_response(status_code=404)
     with pytest.raises(httpx.HTTPStatusError):
         await get_mission_metadata("INVALID_ID", cache)
+
+
+async def test_get_mission_metadata_invalid_json(cache, httpx_mock):
+    """#239: STAC API가 비정상 JSON을 반환하면 None 반환."""
+    httpx_mock.add_response(
+        text="<html>Internal Server Error</html>",
+        headers={"content-type": "text/html"},
+    )
+    result = await get_mission_metadata("S2C_T52SCG_20260225T022315_L2A", cache)
+    assert result is None
+
+
+async def test_mission_uses_settings_timeout(cache, httpx_mock):
+    """#240: mission 모듈이 settings.timeout_mission을 사용하는지 확인."""
+    httpx_mock.add_response(json=SAMPLE_STAC_RESPONSE)
+    await get_mission_metadata("S2C_T52SCG_20260225T022315_L2A", cache)
+
+    request = httpx_mock.get_requests()[0]
+    from app.config import settings
+
+    assert request.extensions["timeout"]["read"] == settings.timeout_mission


### PR DESCRIPTION
## Summary
- **#239**: geocoder, landcover, mission 모듈에서 `resp.json()` 호출 시 `JSONDecodeError`를 catch하여 graceful fallback 처리
- **#240**: mission 모듈의 STAC API 타임아웃을 `settings.timeout_mission`으로 외부화
- **#241**: describer의 `max_image_download_bytes`, `max_image_redirects`를 Settings로 외부화

closes #239, closes #240, closes #241

## Test plan
- [x] geocoder 비정상 JSON 응답 시 Unknown Location 반환 테스트
- [x] landcover 비정상 JSON 응답 시 빈 결과 반환 테스트
- [x] mission 비정상 JSON 응답 시 None 반환 테스트
- [x] mission settings.timeout_mission 사용 테스트
- [x] describer settings.max_image_download_bytes 사용 테스트
- [x] 전체 531 tests passed, 97.29% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)