### PR TITLE
fix(auth,context,metrics): 예외 처리 강화 (#244, #245, #246)

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -263,7 +263,7 @@ async def describe_batch(
             return BatchItemResult(
                 index=index, error="Request timed out", error_detail=error_detail
             )
-        except Exception as e:
+        except (DescriptorError, ConnectionError, OSError) as e:
             error_detail = BatchItemError(
                 error_type="service",
                 message=str(e),
@@ -482,7 +482,7 @@ async def delete_description(
 ):
     try:
         deleted = await db.delete_description(cog_image_id)
-    except Exception as e:
+    except (ConnectionError, TimeoutError, OSError) as e:
         logger.error("delete_description_error", cog_image_id=cog_image_id, error=str(e))
         raise DescriptorError(
             status_code=500,

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,4 +1,5 @@
 import hmac
+import json
 import time
 
 import structlog
@@ -31,7 +32,16 @@ async def _get_jwks() -> dict:
     client = get_client()
     resp = await client.get(url)
     resp.raise_for_status()
-    _jwks_cache = resp.json()
+    try:
+        data = resp.json()
+    except json.JSONDecodeError:
+        logger.warning("jwks_invalid_json", url=url, body=resp.text[:200])
+        raise DescriptorError(
+            status_code=502,
+            code="JWKS_PARSE_ERROR",
+            message="Failed to parse JWKS response from auth provider",
+        )
+    _jwks_cache = data
     _jwks_cache_ts = now
     return _jwks_cache
 

--- a/app/modules/context.py
+++ b/app/modules/context.py
@@ -1,3 +1,5 @@
+import json
+
 import httpx
 import structlog
 
@@ -61,7 +63,7 @@ async def research_context(
                         relevance="low",
                     )
                 )
-    except Exception as e:
+    except (json.JSONDecodeError, httpx.HTTPError, TimeoutError) as e:
         logger.warning("context research failed", error=str(e))
 
     summary = (

--- a/app/utils/metrics.py
+++ b/app/utils/metrics.py
@@ -59,21 +59,14 @@ active_batch_jobs = Gauge(
     "Number of currently running batch jobs",
 )
 
-# In-memory counter mirroring active_batch_jobs gauge (avoids private API access)
-_active_batch_count = 0
-
 
 def batch_job_inc() -> None:
-    global _active_batch_count
     active_batch_jobs.inc()
-    _active_batch_count += 1
 
 
 def batch_job_dec() -> None:
-    global _active_batch_count
     active_batch_jobs.dec()
-    _active_batch_count -= 1
 
 
 def get_active_batch_count() -> int:
-    return _active_batch_count
+    return int(active_batch_jobs._value.get())

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -666,7 +666,9 @@ async def test_delete_description_success(client_with_cache, monkeypatch):
 async def test_delete_description_db_error_returns_500(client_with_cache, monkeypatch):
     import app.db.supabase as db_mod
 
-    monkeypatch.setattr(db_mod, "delete_description", AsyncMock(side_effect=Exception("db error")))
+    monkeypatch.setattr(
+        db_mod, "delete_description", AsyncMock(side_effect=ConnectionError("db error"))
+    )
     resp = await client_with_cache.delete(
         "/api/v1/descriptions/some-id",
         headers={"X-API-Key": os.environ["API_KEY"]},

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -145,6 +145,24 @@ class TestJwksCache:
             # Only one HTTP call due to cache
             assert mock_client.get.call_count == 1
 
+    async def test_jwks_invalid_json(self):
+        """JWKS endpoint returning invalid JSON raises DescriptorError."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        import json
+
+        mock_response.json.side_effect = json.JSONDecodeError("Invalid", "", 0)
+        mock_response.text = "not json"
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch("app.http_client.get_client", return_value=mock_client):
+            with pytest.raises(DescriptorError) as exc_info:
+                await _get_jwks()
+            assert exc_info.value.status_code == 502
+            assert exc_info.value.code == "JWKS_PARSE_ERROR"
+
     async def test_jwks_cache_expired(self):
         import app.auth as auth_module
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -67,7 +67,7 @@ async def test_batch_success(mock_compose, client_with_cache):
 async def test_batch_partial_failure(mock_compose, client_with_cache):
     mock_compose.side_effect = [
         _mock_response(),
-        Exception("external service failed"),
+        ConnectionError("external service failed"),
     ]
     resp = await client_with_cache.post(
         "/api/v1/describe/batch",
@@ -229,7 +229,7 @@ async def test_batch_active_jobs_gauge_zeroed_after_completion(mock_compose, cli
 @patch(
     "app.api.routes.compose_description",
     new_callable=AsyncMock,
-    side_effect=Exception("service error"),
+    side_effect=ConnectionError("service error"),
 )
 async def test_batch_active_jobs_gauge_zeroed_on_exception(mock_compose, client_with_cache):
     """active_batch_jobs gauge is decremented even when batch items raise exceptions."""
@@ -269,7 +269,7 @@ async def test_batch_partial_failure_interrupted_is_zero(mock_compose, client_wi
     """interrupted field is 0 when items fail due to exceptions (not shutdown)."""
     mock_compose.side_effect = [
         _mock_response(),
-        Exception("external service failed"),
+        ConnectionError("external service failed"),
     ]
     resp = await client_with_cache.post(
         "/api/v1/describe/batch",
@@ -298,7 +298,7 @@ async def test_batch_mixed_failed_and_interrupted(mock_compose, client_with_cach
             return _mock_response()
         if call_count == 2:
             monkeypatch.setattr(main_mod, "_shutting_down", True)
-            raise Exception("real failure")
+            raise ConnectionError("real failure")
         return _mock_response()
 
     mock_compose.side_effect = _compose_with_shutdown
@@ -418,7 +418,7 @@ async def test_context_timeout(client_with_cache):
 )
 async def test_batch_error_detail_service(mock_compose, client_with_cache):
     """Batch item service error includes error_detail with error_type='service'."""
-    mock_compose.side_effect = Exception("external service failed")
+    mock_compose.side_effect = ConnectionError("external service failed")
     resp = await client_with_cache.post(
         "/api/v1/describe/batch",
         json={"items": [_make_item()]},

--- a/tests/test_batch_concurrency.py
+++ b/tests/test_batch_concurrency.py
@@ -116,7 +116,7 @@ async def test_individual_failure_does_not_affect_others(batch_client, monkeypat
         nonlocal call_count
         call_count += 1
         if call_count == 2:
-            raise ValueError("test error")
+            raise ConnectionError("test error")
         from app.api.schemas import DescribeResponse
 
         return DescribeResponse(

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -53,8 +53,18 @@ async def test_context_cache_hit(cache, httpx_mock):
 
 
 async def test_context_api_failure(cache, httpx_mock):
-    httpx_mock.add_exception(Exception("Network error"))
+    import httpx
+
+    httpx_mock.add_exception(httpx.DecodingError("Network error"))
 
     result = await research_context("서울", "2025-06-15", cache)
     assert len(result.events) == 0
     assert "찾지 못했습니다" in result.summary
+
+
+async def test_context_unexpected_error_propagates(cache, httpx_mock):
+    """Unexpected exceptions (e.g., programming errors) should propagate."""
+    httpx_mock.add_exception(RuntimeError("Unexpected bug"))
+
+    with pytest.raises(RuntimeError, match="Unexpected bug"):
+        await research_context("서울", "2025-06-15", cache)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -78,6 +78,33 @@ async def test_active_batch_jobs():
     assert get_active_batch_count() == before
 
 
+async def test_batch_counter_gauge_consistency():
+    """Gauge-based counter stays consistent under concurrent inc/dec."""
+    import asyncio
+
+    from app.utils.metrics import (
+        active_batch_jobs,
+        batch_job_dec,
+        batch_job_inc,
+        get_active_batch_count,
+    )
+
+    before = get_active_batch_count()
+    # Reset gauge to known state
+    active_batch_jobs._value.set(0)
+
+    async def inc_dec():
+        batch_job_inc()
+        await asyncio.sleep(0)
+        batch_job_dec()
+
+    await asyncio.gather(*[inc_dec() for _ in range(10)])
+    assert get_active_batch_count() == 0
+
+    # Restore
+    active_batch_jobs._value.set(before)
+
+
 async def test_metrics_endpoint_no_auth():
     """Metrics endpoint should be accessible without auth."""
     from httpx import ASGITransport, AsyncClient


### PR DESCRIPTION
## Summary
- **#244**: `auth.py` JWKS 엔드포인트 JSON 파싱 시 `json.JSONDecodeError` 예외 처리 추가 (502 응답)
- **#245**: `context.py` 및 `routes.py`의 bare `Exception`을 구체적 예외 타입으로 교체
- **#246**: `metrics.py` 전역 배치 카운터 제거, Prometheus gauge 값 직접 사용으로 경쟁 조건 해소

closes #244
closes #245
closes #246

## Test plan
- [x] JWKS 엔드포인트가 잘못된 JSON 반환 시 502 에러 확인 (test_jwks_invalid_json)
- [x] context 연구 실패 시 구체적 예외만 catch, 프로그래밍 에러는 전파 확인
- [x] 배치 카운터 gauge 기반 일관성 테스트 (concurrent inc/dec)
- [x] 기존 534 tests 전체 통과, 커버리지 97.30%

🤖 Generated with [Claude Code](https://claude.com/claude-code)