### PR TITLE
fix(http,cache,db): HTTP 클라이언트 경쟁 조건, 메트릭 라벨 인젝션, ping 타임아웃 수정 (#249, #250, #251)

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -29,7 +29,7 @@ async def _get_jwks() -> dict:
     from app.http_client import get_client
 
     url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
-    client = get_client()
+    client = await get_client()
     resp = await client.get(url)
     resp.raise_for_status()
     try:

--- a/app/cache/store.py
+++ b/app/cache/store.py
@@ -11,6 +11,9 @@ from app.utils.metrics import cache_cleanup_total, cache_errors, cache_hits, cac
 logger = structlog.get_logger()
 
 
+_ALLOWED_MODULES = frozenset({"geocode", "landcover", "mission", "context", "describe"})
+
+
 class CacheStore:
     def __init__(self, db_path: str):
         self._db_path = db_path
@@ -23,7 +26,8 @@ class CacheStore:
         await run_migrations(self._db)
 
     def _module_from_key(self, key: str) -> str:
-        return key.split(":")[0] if ":" in key else "unknown"
+        module = key.split(":")[0] if ":" in key else "unknown"
+        return module if module in _ALLOWED_MODULES else "unknown"
 
     async def get(self, key: str) -> dict | None:
         module = self._module_from_key(key)

--- a/app/config.py
+++ b/app/config.py
@@ -43,6 +43,7 @@ class Settings(BaseSettings):
     timeout_http_client: float = 10.0
     max_image_download_bytes: int = 5 * 1024 * 1024
     max_image_redirects: int = 5
+    timeout_supabase_ping: float = 5.0
 
     @field_validator(
         "cache_ttl_seconds",
@@ -61,6 +62,7 @@ class Settings(BaseSettings):
         "timeout_http_client",
         "max_image_download_bytes",
         "max_image_redirects",
+        "timeout_supabase_ping",
     )
     @classmethod
     def _positive_int(cls, v: int | float, info) -> int | float:
@@ -138,6 +140,7 @@ class Settings(BaseSettings):
             timeout_http_client=self.timeout_http_client,
             max_image_download_bytes=self.max_image_download_bytes,
             max_image_redirects=self.max_image_redirects,
+            timeout_supabase_ping=self.timeout_supabase_ping,
         )
 
     model_config = {"env_file": ".env"}

--- a/app/db/supabase.py
+++ b/app/db/supabase.py
@@ -106,8 +106,14 @@ async def save_description(
 async def ping() -> bool:
     try:
         client = await get_client()
-        await client.table("image_descriptions").select("cog_image_id").limit(1).execute()
+        await asyncio.wait_for(
+            client.table("image_descriptions").select("cog_image_id").limit(1).execute(),
+            timeout=settings.timeout_supabase_ping,
+        )
         return True
+    except TimeoutError:
+        logger.warning("supabase ping timed out", timeout=settings.timeout_supabase_ping)
+        return False
     except Exception as e:
         _reset_client()
         logger.warning("supabase ping failed", error=str(e))

--- a/app/http_client.py
+++ b/app/http_client.py
@@ -1,16 +1,36 @@
 """Shared httpx.AsyncClient for connection pooling across modules."""
 
+import asyncio
+
 import httpx
 
 from app.config import settings
 
 _client: httpx.AsyncClient | None = None
+_lock: asyncio.Lock | None = None
 
 
-def get_client() -> httpx.AsyncClient:
-    """Return the shared httpx.AsyncClient, creating it lazily if needed."""
+def _get_lock() -> asyncio.Lock:
+    """Return the module-level lock, creating it lazily (safe in single-threaded asyncio)."""
+    global _lock
+    if _lock is None:
+        _lock = asyncio.Lock()
+    return _lock
+
+
+async def get_client() -> httpx.AsyncClient:
+    """Return the shared httpx.AsyncClient, creating it lazily if needed.
+
+    Uses an asyncio.Lock to prevent race conditions when multiple
+    coroutines call this concurrently.
+    """
     global _client
-    if _client is None or _client.is_closed:
+    if _client is not None and not _client.is_closed:
+        return _client
+    async with _get_lock():
+        # Double-check after acquiring lock
+        if _client is not None and not _client.is_closed:
+            return _client
         _client = httpx.AsyncClient(
             limits=httpx.Limits(
                 max_connections=100,
@@ -18,7 +38,7 @@ def get_client() -> httpx.AsyncClient:
             ),
             timeout=httpx.Timeout(settings.timeout_http_client),
         )
-    return _client
+        return _client
 
 
 async def close_client() -> None:

--- a/app/modules/context.py
+++ b/app/modules/context.py
@@ -14,7 +14,7 @@ logger = structlog.get_logger()
 
 @retry_http
 async def _fetch_duckduckgo(query: str) -> httpx.Response:
-    client = get_client()
+    client = await get_client()
     resp = await client.get(
         "https://api.duckduckgo.com/",
         params={"q": query, "format": "json", "no_html": 1},

--- a/app/modules/describer.py
+++ b/app/modules/describer.py
@@ -113,7 +113,7 @@ async def _download_image(url: str) -> bytes:
     from app.http_client import get_client
 
     current_url = url
-    http_client = get_client()
+    http_client = await get_client()
     for _ in range(max_redirects + 1):
         async with http_client.stream(
             "GET", current_url, timeout=settings.timeout_describer

--- a/app/modules/geocoder.py
+++ b/app/modules/geocoder.py
@@ -25,7 +25,7 @@ def _round_coords(lon: float, lat: float, decimals: int = 3) -> tuple[float, flo
 
 @retry_http
 async def _fetch_nominatim(lon: float, lat: float) -> httpx.Response:
-    client = get_client()
+    client = await get_client()
     resp = await client.get(
         f"{settings.nominatim_url}/reverse",
         params={

--- a/app/modules/landcover.py
+++ b/app/modules/landcover.py
@@ -52,7 +52,7 @@ def _round_coords(lon: float, lat: float) -> tuple[float, float]:
 
 @retry_http
 async def _fetch_overpass(query: str) -> httpx.Response:
-    client = get_client()
+    client = await get_client()
     resp = await client.post(
         settings.overpass_url,
         data={"data": query},

--- a/app/modules/mission.py
+++ b/app/modules/mission.py
@@ -24,7 +24,7 @@ _COLLECTION_PROCESSING_LEVEL = {
 async def _fetch_stac_item(stac_id: str) -> httpx.Response:
     collection = _guess_collection(stac_id)
     url = f"{STAC_BASE_URL}/collections/{collection}/items/{stac_id}"
-    client = get_client()
+    client = await get_client()
     resp = await client.get(url, timeout=settings.timeout_mission)
     resp.raise_for_status()
     return resp

--- a/tests/test_cache_stats.py
+++ b/tests/test_cache_stats.py
@@ -107,6 +107,21 @@ class TestCacheStats:
         stats = await cache.stats()
         assert stats["modules"]["geocode"]["hit_rate"] == 0.0
 
+    async def test_module_from_key_rejects_invalid_module(self, cache):
+        """#250: Invalid module names should be sanitized to 'unknown'."""
+        await cache.get("malicious\\ninjection:x")
+        stats = await cache.stats()
+        assert "malicious\\ninjection" not in stats["modules"]
+        assert "unknown" in stats["modules"]
+
+    async def test_module_from_key_allows_valid_modules(self, cache):
+        """#250: Valid module names should pass through."""
+        for module in ("geocode", "landcover", "mission", "context", "describe"):
+            await cache.get(f"{module}:test")
+        stats = await cache.stats()
+        for module in ("geocode", "landcover", "mission", "context", "describe"):
+            assert module in stats["modules"]
+
 
 class TestCacheStatsEndpoint:
     @pytest.fixture

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,4 +1,6 @@
-"""Tests for shared httpx client module (#225)."""
+"""Tests for shared httpx client module (#225, #249)."""
+
+import asyncio
 
 import httpx
 import pytest
@@ -11,33 +13,41 @@ from app.http_client import close_client, get_client
 async def _reset_client():
     """Reset the global client before and after each test."""
     http_client_mod._client = None
+    http_client_mod._lock = None
     yield
     if http_client_mod._client is not None and not http_client_mod._client.is_closed:
         await http_client_mod._client.aclose()
     http_client_mod._client = None
+    http_client_mod._lock = None
 
 
-def test_get_client_returns_async_client():
-    client = get_client()
+async def test_get_client_returns_async_client():
+    client = await get_client()
     assert isinstance(client, httpx.AsyncClient)
 
 
-def test_get_client_returns_same_instance():
-    client1 = get_client()
-    client2 = get_client()
+async def test_get_client_returns_same_instance():
+    client1 = await get_client()
+    client2 = await get_client()
     assert client1 is client2
 
 
 async def test_close_client():
-    client = get_client()
+    client = await get_client()
     assert not client.is_closed
     await close_client()
     assert client.is_closed
 
 
 async def test_get_client_after_close():
-    client1 = get_client()
+    client1 = await get_client()
     await close_client()
-    client2 = get_client()
+    client2 = await get_client()
     assert not client2.is_closed
     assert client1 is not client2
+
+
+async def test_concurrent_get_client_returns_single_instance():
+    """#249: Concurrent calls should produce only one client instance."""
+    results = await asyncio.gather(*(get_client() for _ in range(10)))
+    assert all(r is results[0] for r in results)

--- a/tests/test_supabase.py
+++ b/tests/test_supabase.py
@@ -350,3 +350,18 @@ class TestClientReinitialization:
         result = await db_module.ping()
         assert result is False
         assert db_module._client is None
+
+    async def test_ping_timeout_returns_false(self):
+        """#251: ping should return False on timeout without resetting client."""
+        mock_client = MagicMock()
+
+        async def slow_execute():
+            await asyncio.sleep(20)
+
+        mock_client.table.return_value.select.return_value.limit.return_value.execute = slow_execute
+        db_module._client = mock_client
+        with patch.object(db_module.settings, "timeout_supabase_ping", 0.1):
+            result = await db_module.ping()
+        assert result is False
+        # Client should NOT be reset on timeout (it's not a connection error)
+        assert db_module._client is mock_client


### PR DESCRIPTION
## Summary
- **#249**: `get_client()`를 `asyncio.Lock` 기반 async 함수로 전환하여 동시 호출 시 단일 인스턴스 보장 (double-check locking)
- **#250**: `CacheStore._module_from_key()`에 허용 모듈명 화이트리스트(`geocode`, `landcover`, `mission`, `context`, `describe`) 검증 추가, 유효하지 않은 모듈명은 `"unknown"`으로 대체
- **#251**: `ping()`에 `asyncio.wait_for()` 타임아웃 적용, `timeout_supabase_ping` 설정값 외부화 (기본 5초)

closes #249
closes #250
closes #251

## Test plan
- [x] 동시 `get_client()` 호출 시 단일 인스턴스 반환 확인 (test_concurrent_get_client_returns_single_instance)
- [x] 악의적 모듈명이 "unknown"으로 치환되는지 확인 (test_module_from_key_rejects_invalid_module)
- [x] 유효한 모듈명 5종이 정상 통과하는지 확인 (test_module_from_key_allows_valid_modules)
- [x] ping 타임아웃 시 False 반환, 클라이언트 미리셋 확인 (test_ping_timeout_returns_false)
- [x] 전체 538 tests passed, 97%+ coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)