### PR TITLE
fix(auth,db,api,cache): 하드코딩 상수 외부화 (#254, #255, #256)

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -106,14 +106,13 @@ async def health(request: Request):
     except PackageNotFoundError:
         ver = "unknown"
 
-    _health_timeout = 3.0
     cache = request.app.state.cache
     try:
-        cache_ok = await asyncio.wait_for(cache.ping(), timeout=_health_timeout)
+        cache_ok = await asyncio.wait_for(cache.ping(), timeout=settings.health_timeout)
     except TimeoutError:
         cache_ok = False
     try:
-        supabase_ok = await asyncio.wait_for(db.ping(), timeout=_health_timeout)
+        supabase_ok = await asyncio.wait_for(db.ping(), timeout=settings.health_timeout)
     except TimeoutError:
         supabase_ok = False
 

--- a/app/auth.py
+++ b/app/auth.py
@@ -17,14 +17,13 @@ bearer_scheme = HTTPBearer(auto_error=False)
 
 _jwks_cache: dict | None = None
 _jwks_cache_ts: float = 0.0
-_JWKS_TTL: float = 3600.0
 
 
 async def _get_jwks() -> dict:
     """Fetch Supabase JWKS public keys (cached with TTL)."""
     global _jwks_cache, _jwks_cache_ts
     now = time.monotonic()
-    if _jwks_cache and (now - _jwks_cache_ts) < _JWKS_TTL:
+    if _jwks_cache and (now - _jwks_cache_ts) < settings.jwks_ttl_seconds:
         return _jwks_cache
     from app.http_client import get_client
 

--- a/app/config.py
+++ b/app/config.py
@@ -44,6 +44,13 @@ class Settings(BaseSettings):
     max_image_download_bytes: int = 5 * 1024 * 1024
     max_image_redirects: int = 5
     timeout_supabase_ping: float = 5.0
+    jwks_ttl_seconds: float = 3600.0
+    supabase_save_timeout: float = 10.0
+    supabase_reconnect_backoff_base: float = 1.0
+    supabase_reconnect_backoff_max: float = 60.0
+    health_timeout: float = 3.0
+    cache_cleanup_poll_interval: float = 0.5
+    overpass_timeout: int = 10
 
     @field_validator(
         "cache_ttl_seconds",
@@ -63,6 +70,13 @@ class Settings(BaseSettings):
         "max_image_download_bytes",
         "max_image_redirects",
         "timeout_supabase_ping",
+        "jwks_ttl_seconds",
+        "supabase_save_timeout",
+        "supabase_reconnect_backoff_base",
+        "supabase_reconnect_backoff_max",
+        "health_timeout",
+        "cache_cleanup_poll_interval",
+        "overpass_timeout",
     )
     @classmethod
     def _positive_int(cls, v: int | float, info) -> int | float:
@@ -141,6 +155,13 @@ class Settings(BaseSettings):
             max_image_download_bytes=self.max_image_download_bytes,
             max_image_redirects=self.max_image_redirects,
             timeout_supabase_ping=self.timeout_supabase_ping,
+            jwks_ttl_seconds=self.jwks_ttl_seconds,
+            supabase_save_timeout=self.supabase_save_timeout,
+            supabase_reconnect_backoff_base=self.supabase_reconnect_backoff_base,
+            supabase_reconnect_backoff_max=self.supabase_reconnect_backoff_max,
+            health_timeout=self.health_timeout,
+            cache_cleanup_poll_interval=self.cache_cleanup_poll_interval,
+            overpass_timeout=self.overpass_timeout,
         )
 
     model_config = {"env_file": ".env"}

--- a/app/db/supabase.py
+++ b/app/db/supabase.py
@@ -6,10 +6,6 @@ from supabase import AsyncClient, acreate_client
 
 from app.config import settings
 
-SAVE_TIMEOUT_SECONDS = 10
-_RECONNECT_BACKOFF_BASE = 1.0
-_RECONNECT_BACKOFF_MAX = 60.0
-
 logger = structlog.get_logger()
 
 _client: AsyncClient | None = None
@@ -35,8 +31,8 @@ async def get_client() -> AsyncClient:
         # Apply exponential backoff if we had recent failures
         if _consecutive_failures > 0:
             backoff = min(
-                _RECONNECT_BACKOFF_BASE * (2 ** (_consecutive_failures - 1)),
-                _RECONNECT_BACKOFF_MAX,
+                settings.supabase_reconnect_backoff_base * (2 ** (_consecutive_failures - 1)),
+                settings.supabase_reconnect_backoff_max,
             )
             elapsed = time.monotonic() - _last_failure_time
             if elapsed < backoff:
@@ -88,7 +84,7 @@ async def save_description(
 
         await asyncio.wait_for(
             client.table("image_descriptions").upsert(row, on_conflict="cog_image_id").execute(),
-            timeout=SAVE_TIMEOUT_SECONDS,
+            timeout=settings.supabase_save_timeout,
         )
         logger.info("saved description to supabase", cog_image_id=cog_image_id)
         return True

--- a/app/main.py
+++ b/app/main.py
@@ -87,7 +87,7 @@ async def lifespan(app: FastAPI):
         from app.utils.metrics import get_active_batch_count
 
         batch_timeout = settings.shutdown_batch_timeout
-        poll_interval = 0.5
+        poll_interval = settings.cache_cleanup_poll_interval
         elapsed = 0.0
         while get_active_batch_count() > 0 and elapsed < batch_timeout:
             await asyncio.sleep(poll_interval)

--- a/app/modules/landcover.py
+++ b/app/modules/landcover.py
@@ -72,7 +72,7 @@ async def get_land_cover(lon: float, lat: float, cache: CacheStore) -> LandCover
         return LandCover(**cached)
 
     query = f"""
-[out:json][timeout:10];
+[out:json][timeout:{settings.overpass_timeout}];
 (
   way["landuse"](around:2000,{lat},{lon});
   way["natural"](around:2000,{lat},{lon});

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,7 +6,8 @@ import pytest
 from fastapi.security import HTTPAuthorizationCredentials
 from jose import JWTError
 
-from app.auth import _JWKS_TTL, _get_jwks, authenticate
+from app.auth import _get_jwks, authenticate
+from app.config import settings
 from app.utils.errors import DescriptorError
 
 FAKE_JWKS = {
@@ -179,7 +180,7 @@ class TestJwksCache:
             # First fetch
             await _get_jwks()
             # Expire the cache
-            auth_module._jwks_cache_ts = time.monotonic() - _JWKS_TTL - 1
+            auth_module._jwks_cache_ts = time.monotonic() - settings.jwks_ttl_seconds - 1
             # Second fetch should call HTTP again
             await _get_jwks()
             assert mock_client.get.call_count == 2

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -124,6 +124,54 @@ class TestOverrides:
                 Settings()
 
 
+class TestExternalizedConstants:
+    def test_default_jwks_ttl(self):
+        with patch.dict(os.environ, _make_env(), clear=True):
+            s = Settings()
+            assert s.jwks_ttl_seconds == 3600.0
+
+    def test_default_supabase_save_timeout(self):
+        with patch.dict(os.environ, _make_env(), clear=True):
+            s = Settings()
+            assert s.supabase_save_timeout == 10.0
+
+    def test_default_supabase_reconnect_backoff(self):
+        with patch.dict(os.environ, _make_env(), clear=True):
+            s = Settings()
+            assert s.supabase_reconnect_backoff_base == 1.0
+            assert s.supabase_reconnect_backoff_max == 60.0
+
+    def test_default_health_timeout(self):
+        with patch.dict(os.environ, _make_env(), clear=True):
+            s = Settings()
+            assert s.health_timeout == 3.0
+
+    def test_default_cache_cleanup_poll_interval(self):
+        with patch.dict(os.environ, _make_env(), clear=True):
+            s = Settings()
+            assert s.cache_cleanup_poll_interval == 0.5
+
+    def test_default_overpass_timeout(self):
+        with patch.dict(os.environ, _make_env(), clear=True):
+            s = Settings()
+            assert s.overpass_timeout == 10
+
+    def test_custom_jwks_ttl(self):
+        with patch.dict(os.environ, _make_env(JWKS_TTL_SECONDS="1800"), clear=True):
+            s = Settings()
+            assert s.jwks_ttl_seconds == 1800.0
+
+    def test_custom_supabase_save_timeout(self):
+        with patch.dict(os.environ, _make_env(SUPABASE_SAVE_TIMEOUT="30"), clear=True):
+            s = Settings()
+            assert s.supabase_save_timeout == 30.0
+
+    def test_custom_overpass_timeout(self):
+        with patch.dict(os.environ, _make_env(OVERPASS_TIMEOUT="20"), clear=True):
+            s = Settings()
+            assert s.overpass_timeout == 20
+
+
 class TestPositiveIntValidation:
     @pytest.mark.parametrize(
         "field",
@@ -135,6 +183,13 @@ class TestPositiveIntValidation:
             "BATCH_CONCURRENCY",
             "THUMBNAIL_MAX_PIXELS",
             "GZIP_MIN_SIZE",
+            "JWKS_TTL_SECONDS",
+            "SUPABASE_SAVE_TIMEOUT",
+            "SUPABASE_RECONNECT_BACKOFF_BASE",
+            "SUPABASE_RECONNECT_BACKOFF_MAX",
+            "HEALTH_TIMEOUT",
+            "CACHE_CLEANUP_POLL_INTERVAL",
+            "OVERPASS_TIMEOUT",
         ],
     )
     def test_zero_rejected(self, field):

--- a/tests/test_supabase.py
+++ b/tests/test_supabase.py
@@ -139,7 +139,7 @@ class TestSaveDescription:
         with patch.object(
             db_module, "get_client", new_callable=AsyncMock, return_value=mock_client
         ):
-            with patch.object(db_module, "SAVE_TIMEOUT_SECONDS", 0.1):
+            with patch.object(db_module.settings, "supabase_save_timeout", 0.1):
                 result = await db_module.save_description(
                     cog_image_id="test-img",
                     coordinates=[127.0, 37.0],


### PR DESCRIPTION
## Summary
- JWKS TTL을 `settings.jwks_ttl_seconds`로 외부화 (closes #254)
- Supabase save timeout, reconnect backoff base/max를 settings로 외부화 (closes #255)
- health_timeout, cache_cleanup_poll_interval, overpass_timeout을 settings로 외부화 (closes #256)

## Changes
- `app/config.py`: 7개 새 설정 필드 추가 (양수 검증 포함)
- `app/auth.py`: `_JWKS_TTL` 상수 제거, `settings.jwks_ttl_seconds` 참조
- `app/db/supabase.py`: `SAVE_TIMEOUT_SECONDS`, `_RECONNECT_BACKOFF_*` 상수 제거, settings 참조
- `app/api/routes.py`: `_health_timeout` 로컬 변수 제거, `settings.health_timeout` 참조
- `app/main.py`: `poll_interval` 하드코딩 제거, `settings.cache_cleanup_poll_interval` 참조
- `app/modules/landcover.py`: Overpass `[timeout:10]` → `settings.overpass_timeout` 참조

## Test plan
- [x] 554 tests passed, 97.26% coverage
- [x] 새 설정 필드 기본값 테스트 추가
- [x] 커스텀값 오버라이드 테스트 추가
- [x] 양수 검증 (0 거부) 테스트 추가
- [x] 기존 테스트 모두 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)