### PR TITLE
fix(auth,geocoder,circuit_breaker): JWKS 락, deprecated API, CB 레이스 컨디션 수정

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -1,3 +1,4 @@
+import asyncio
 import hmac
 import json
 import time
@@ -17,6 +18,7 @@ bearer_scheme = HTTPBearer(auto_error=False)
 
 _jwks_cache: dict | None = None
 _jwks_cache_ts: float = 0.0
+_jwks_lock = asyncio.Lock()
 
 
 async def _get_jwks() -> dict:
@@ -25,24 +27,29 @@ async def _get_jwks() -> dict:
     now = time.monotonic()
     if _jwks_cache and (now - _jwks_cache_ts) < settings.jwks_ttl_seconds:
         return _jwks_cache
-    from app.http_client import get_client
+    async with _jwks_lock:
+        # Double-check after acquiring lock
+        now = time.monotonic()
+        if _jwks_cache and (now - _jwks_cache_ts) < settings.jwks_ttl_seconds:
+            return _jwks_cache
+        from app.http_client import get_client
 
-    url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
-    client = await get_client()
-    resp = await client.get(url)
-    resp.raise_for_status()
-    try:
-        data = resp.json()
-    except json.JSONDecodeError:
-        logger.warning("jwks_invalid_json", url=url, body=resp.text[:200])
-        raise DescriptorError(
-            status_code=502,
-            code="JWKS_PARSE_ERROR",
-            message="Failed to parse JWKS response from auth provider",
-        )
-    _jwks_cache = data
-    _jwks_cache_ts = now
-    return _jwks_cache
+        url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
+        client = await get_client()
+        resp = await client.get(url)
+        resp.raise_for_status()
+        try:
+            data = resp.json()
+        except json.JSONDecodeError:
+            logger.warning("jwks_invalid_json", url=url, body=resp.text[:200])
+            raise DescriptorError(
+                status_code=502,
+                code="JWKS_PARSE_ERROR",
+                message="Failed to parse JWKS response from auth provider",
+            )
+        _jwks_cache = data
+        _jwks_cache_ts = now
+        return _jwks_cache
 
 
 def _verify_jwt(token: str, jwks: dict) -> dict:

--- a/app/modules/geocoder.py
+++ b/app/modules/geocoder.py
@@ -54,13 +54,13 @@ async def geocode(lon: float, lat: float, cache: CacheStore) -> Location:
     global _last_request_time
     async with _semaphore:
         # 1 req/sec 속도 제한
-        now = asyncio.get_event_loop().time()
+        now = asyncio.get_running_loop().time()
         wait = max(0, 1.0 - (now - _last_request_time))
         if wait > 0:
             await asyncio.sleep(wait)
 
         resp = await _fetch_nominatim(lon, lat)
-        _last_request_time = asyncio.get_event_loop().time()
+        _last_request_time = asyncio.get_running_loop().time()
 
     try:
         data = resp.json()

--- a/app/services/composer.py
+++ b/app/services/composer.py
@@ -38,12 +38,12 @@ async def _safe_call(name: str, coro: Awaitable, warnings: list[Warning]):
     t0 = time.monotonic()
     try:
         result = await coro
-        cb.record_success()
+        await cb.record_success()
         external_api_requests.labels(service=name, status="success").inc()
         external_api_duration.labels(service=name).observe(time.monotonic() - t0)
         return result
     except Exception as e:
-        cb.record_failure()
+        await cb.record_failure()
         external_api_requests.labels(service=name, status="error").inc()
         external_api_duration.labels(service=name).observe(time.monotonic() - t0)
         logger.error("external_call_failed", service=name, error=str(e))

--- a/app/utils/circuit_breaker.py
+++ b/app/utils/circuit_breaker.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 
 import structlog
@@ -16,6 +17,7 @@ class CircuitBreaker:
         self.cooldown_sec = cooldown_sec
         self._failure_count = 0
         self._open_until = 0.0
+        self._lock = asyncio.Lock()
 
     @property
     def is_open(self) -> bool:
@@ -28,11 +30,6 @@ class CircuitBreaker:
             circuit_breaker_state.labels(name=self.name).set(2)
         return False
 
-    def record_success(self):
-        self._failure_count = 0
-        self._open_until = 0.0
-        circuit_breaker_state.labels(name=self.name).set(0)
-
     def get_status(self) -> dict:
         is_open = self.is_open
         cooldown_remaining = max(0.0, self._open_until - time.time()) if is_open else 0.0
@@ -43,13 +40,20 @@ class CircuitBreaker:
             "cooldown_remaining": round(cooldown_remaining, 1),
         }
 
-    def record_failure(self):
-        self._failure_count += 1
-        if self._failure_count >= self.failure_threshold:
-            self._open_until = time.time() + self.cooldown_sec
-            circuit_breaker_state.labels(name=self.name).set(1)
-            logger.warning(
-                "circuit breaker opened",
-                name=self.name,
-                cooldown=self.cooldown_sec,
-            )
+    async def record_failure(self):
+        async with self._lock:
+            self._failure_count += 1
+            if self._failure_count >= self.failure_threshold:
+                self._open_until = time.time() + self.cooldown_sec
+                circuit_breaker_state.labels(name=self.name).set(1)
+                logger.warning(
+                    "circuit breaker opened",
+                    name=self.name,
+                    cooldown=self.cooldown_sec,
+                )
+
+    async def record_success(self):
+        async with self._lock:
+            self._failure_count = 0
+            self._open_until = 0.0
+            circuit_breaker_state.labels(name=self.name).set(0)

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -11,49 +11,49 @@ from app.utils.circuit_breaker import CircuitBreaker
 class TestCircuitBreakerClosed:
     """Tests for normal (closed) circuit behavior."""
 
-    def test_initial_state_is_closed(self):
+    async def test_initial_state_is_closed(self):
         cb = CircuitBreaker("test")
         assert not cb.is_open
 
-    def test_stays_closed_after_success(self):
+    async def test_stays_closed_after_success(self):
         cb = CircuitBreaker("test")
-        cb.record_success()
+        await cb.record_success()
         assert not cb.is_open
 
-    def test_stays_closed_below_threshold(self):
+    async def test_stays_closed_below_threshold(self):
         cb = CircuitBreaker("test", failure_threshold=5)
         for _ in range(4):
-            cb.record_failure()
+            await cb.record_failure()
         assert not cb.is_open
 
-    def test_success_resets_failure_count(self):
+    async def test_success_resets_failure_count(self):
         cb = CircuitBreaker("test", failure_threshold=3)
-        cb.record_failure()
-        cb.record_failure()
-        cb.record_success()
+        await cb.record_failure()
+        await cb.record_failure()
+        await cb.record_success()
         # After reset, 2 more failures should not open
-        cb.record_failure()
-        cb.record_failure()
+        await cb.record_failure()
+        await cb.record_failure()
         assert not cb.is_open
 
 
 class TestCircuitBreakerOpen:
     """Tests for open circuit behavior."""
 
-    def test_opens_at_threshold(self):
+    async def test_opens_at_threshold(self):
         cb = CircuitBreaker("test", failure_threshold=3, cooldown_sec=10.0)
         for _ in range(3):
-            cb.record_failure()
+            await cb.record_failure()
         assert cb.is_open
 
-    def test_opens_exactly_at_threshold(self):
+    async def test_opens_exactly_at_threshold(self):
         cb = CircuitBreaker("test", failure_threshold=1)
-        cb.record_failure()
+        await cb.record_failure()
         assert cb.is_open
 
-    def test_stays_open_during_cooldown(self):
+    async def test_stays_open_during_cooldown(self):
         cb = CircuitBreaker("test", failure_threshold=1, cooldown_sec=100.0)
-        cb.record_failure()
+        await cb.record_failure()
         assert cb.is_open
         assert cb.is_open  # Still open on second check
 
@@ -61,56 +61,56 @@ class TestCircuitBreakerOpen:
 class TestCircuitBreakerHalfOpen:
     """Tests for half-open state after cooldown expires."""
 
-    def test_resets_after_cooldown(self):
+    async def test_resets_after_cooldown(self):
         cb = CircuitBreaker("test", failure_threshold=1, cooldown_sec=0.0)
-        cb.record_failure()
+        await cb.record_failure()
         # cooldown_sec=0 means it expires immediately
         assert not cb.is_open  # half-open → reset
 
-    def test_resets_with_short_cooldown(self):
+    async def test_resets_with_short_cooldown(self):
         cb = CircuitBreaker("test", failure_threshold=1, cooldown_sec=0.05)
-        cb.record_failure()
+        await cb.record_failure()
         assert cb.is_open
         time.sleep(0.06)
         # After cooldown, should transition to half-open (closed)
         assert not cb.is_open
 
-    def test_reopens_on_failure_after_halfopen(self):
+    async def test_reopens_on_failure_after_halfopen(self):
         cb = CircuitBreaker("test", failure_threshold=1, cooldown_sec=0.05)
-        cb.record_failure()
+        await cb.record_failure()
         assert cb.is_open
         time.sleep(0.06)
         # After cooldown, half-open reset
         assert not cb.is_open
         # Another failure should re-open
-        cb.record_failure()
+        await cb.record_failure()
         assert cb.is_open
 
-    def test_stays_closed_on_success_after_halfopen(self):
+    async def test_stays_closed_on_success_after_halfopen(self):
         cb = CircuitBreaker("test", failure_threshold=1, cooldown_sec=0.0)
-        cb.record_failure()
+        await cb.record_failure()
         assert not cb.is_open  # half-open reset
-        cb.record_success()
+        await cb.record_success()
         assert not cb.is_open
 
 
 class TestCircuitBreakerEdgeCases:
     """Edge cases and boundary tests."""
 
-    def test_multiple_successes_no_effect(self):
+    async def test_multiple_successes_no_effect(self):
         cb = CircuitBreaker("test")
         for _ in range(100):
-            cb.record_success()
+            await cb.record_success()
         assert not cb.is_open
 
-    def test_custom_parameters(self):
+    async def test_custom_parameters(self):
         cb = CircuitBreaker("custom", failure_threshold=2, cooldown_sec=60.0)
-        cb.record_failure()
+        await cb.record_failure()
         assert not cb.is_open
-        cb.record_failure()
+        await cb.record_failure()
         assert cb.is_open
 
-    def test_name_preserved(self):
+    async def test_name_preserved(self):
         cb = CircuitBreaker("my-service")
         assert cb.name == "my-service"
 

--- a/tests/test_circuit_breaker_lock.py
+++ b/tests/test_circuit_breaker_lock.py
@@ -1,0 +1,31 @@
+"""Tests for CircuitBreaker asyncio.Lock (concurrent state consistency)."""
+
+import asyncio
+
+from app.utils.circuit_breaker import CircuitBreaker
+
+
+class TestCircuitBreakerConcurrency:
+    async def test_concurrent_failures_consistent_count(self):
+        """Concurrent record_failure calls should produce consistent failure count."""
+        cb = CircuitBreaker("test", failure_threshold=100, cooldown_sec=30.0)
+        await asyncio.gather(*[cb.record_failure() for _ in range(50)])
+        assert cb._failure_count == 50
+
+    async def test_concurrent_success_resets(self):
+        """Concurrent record_success calls should all reset cleanly."""
+        cb = CircuitBreaker("test", failure_threshold=100, cooldown_sec=30.0)
+        # Add some failures first
+        for _ in range(10):
+            await cb.record_failure()
+        await asyncio.gather(*[cb.record_success() for _ in range(10)])
+        assert cb._failure_count == 0
+        assert not cb.is_open
+
+    async def test_concurrent_mixed_operations(self):
+        """Mixed concurrent success/failure should not corrupt state."""
+        cb = CircuitBreaker("test", failure_threshold=100, cooldown_sec=30.0)
+        tasks = [cb.record_failure() for _ in range(20)] + [cb.record_success() for _ in range(5)]
+        await asyncio.gather(*tasks)
+        # State should be internally consistent (no exceptions, valid count)
+        assert cb._failure_count >= 0

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -7,7 +7,7 @@ from app.utils.circuit_breaker import CircuitBreaker
 
 
 class TestCircuitBreakerGetStatus:
-    def test_closed_status(self):
+    async def test_closed_status(self):
         cb = CircuitBreaker("geocoder")
         status = cb.get_status()
         assert status["name"] == "geocoder"
@@ -15,18 +15,18 @@ class TestCircuitBreakerGetStatus:
         assert status["failure_count"] == 0
         assert status["cooldown_remaining"] == 0.0
 
-    def test_open_status(self):
+    async def test_open_status(self):
         cb = CircuitBreaker("geocoder", failure_threshold=2, cooldown_sec=30.0)
-        cb.record_failure()
-        cb.record_failure()
+        await cb.record_failure()
+        await cb.record_failure()
         status = cb.get_status()
         assert status["state"] == "open"
         assert status["failure_count"] == 2
         assert status["cooldown_remaining"] > 0
 
-    def test_cooldown_remaining_decreases(self):
+    async def test_cooldown_remaining_decreases(self):
         cb = CircuitBreaker("geocoder", failure_threshold=1, cooldown_sec=10.0)
-        cb.record_failure()
+        await cb.record_failure()
         with patch("app.utils.circuit_breaker.time") as mock_time:
             mock_time.time.return_value = time.time() + 5
             status = cb.get_status()

--- a/tests/test_jwks_lock.py
+++ b/tests/test_jwks_lock.py
@@ -1,0 +1,61 @@
+"""Tests for JWKS cache lock (concurrent request deduplication)."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.auth import _get_jwks
+
+FAKE_JWKS = {"keys": [{"kty": "RSA", "kid": "test"}]}
+
+
+@pytest.fixture(autouse=True)
+def reset_jwks_cache():
+    """Reset JWKS cache before each test."""
+    import app.auth as auth_mod
+
+    auth_mod._jwks_cache = None
+    auth_mod._jwks_cache_ts = 0.0
+    yield
+    auth_mod._jwks_cache = None
+    auth_mod._jwks_cache_ts = 0.0
+
+
+class TestJwksLock:
+    async def test_concurrent_requests_single_fetch(self):
+        """10 concurrent _get_jwks calls should result in only 1 HTTP fetch."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = FAKE_JWKS
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        with patch("app.http_client.get_client", return_value=mock_client):
+            results = await asyncio.gather(*[_get_jwks() for _ in range(10)])
+
+        assert all(r == FAKE_JWKS for r in results)
+        assert mock_client.get.call_count == 1
+
+    async def test_cache_expiry_refetches(self):
+        """After TTL expires, a new fetch should occur."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = FAKE_JWKS
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        with (
+            patch("app.http_client.get_client", return_value=mock_client),
+            patch("app.auth.settings") as mock_settings,
+        ):
+            mock_settings.jwks_ttl_seconds = 0.0
+            mock_settings.supabase_url = "https://fake.supabase.co"
+            result1 = await _get_jwks()
+            result2 = await _get_jwks()
+
+        assert result1 == FAKE_JWKS
+        assert result2 == FAKE_JWKS
+        assert mock_client.get.call_count == 2


### PR DESCRIPTION
## Summary
- **#258**: `_get_jwks()`에 `asyncio.Lock` 적용 (double-checked locking) → 동시 요청 시 JWKS fetch 1회로 제한
- **#259**: `asyncio.get_event_loop().time()` → `asyncio.get_running_loop().time()` 교체 (DeprecationWarning 제거)
- **#260**: `CircuitBreaker.record_failure()`/`record_success()`를 async로 전환 + `asyncio.Lock` 적용 → TOCTOU 레이스 컨디션 수정

closes #258, closes #259, closes #260

## Test plan
- [x] JWKS 동시 10개 요청 시 fetch 1회만 발생 확인
- [x] JWKS 캐시 만료 후 재fetch 정상 동작 확인
- [x] CircuitBreaker 동시 50개 failure 호출 시 카운트 일관성 확인
- [x] 기존 559개 테스트 통과, 커버리지 97.22%

🤖 Generated with [Claude Code](https://claude.com/claude-code)