### PR TITLE
fix(geocoder,circuit_breaker,db): 비동기 경쟁 조건 수정 (#262, #263, #264)

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -84,7 +84,7 @@ async def cache_stats(request: Request):
     "(open/closed, 실패 횟수, cooldown 잔여 시간)를 반환합니다.",
 )
 async def circuit_breaker_status():
-    return CircuitBreakerResponse(breakers=get_breaker_statuses())
+    return CircuitBreakerResponse(breakers=await get_breaker_statuses())
 
 
 @router.get(

--- a/app/db/supabase.py
+++ b/app/db/supabase.py
@@ -11,6 +11,15 @@ logger = structlog.get_logger()
 _client: AsyncClient | None = None
 _last_failure_time: float = 0.0
 _consecutive_failures: int = 0
+_lock: asyncio.Lock | None = None
+
+
+def _get_lock() -> asyncio.Lock:
+    """Return the module-level lock, creating it lazily (safe in single-threaded asyncio)."""
+    global _lock
+    if _lock is None:
+        _lock = asyncio.Lock()
+    return _lock
 
 
 def _reset_client() -> None:
@@ -27,7 +36,11 @@ def _reset_client() -> None:
 
 async def get_client() -> AsyncClient:
     global _client, _consecutive_failures
-    if _client is None:
+    if _client is not None:
+        return _client
+    async with _get_lock():
+        if _client is not None:
+            return _client
         # Apply exponential backoff if we had recent failures
         if _consecutive_failures > 0:
             backoff = min(

--- a/app/modules/geocoder.py
+++ b/app/modules/geocoder.py
@@ -14,7 +14,7 @@ from app.utils.retry import retry_http
 logger = structlog.get_logger()
 
 # Nominatim 사용 정책: 1 req/sec
-_semaphore = asyncio.Semaphore(1)
+_lock = asyncio.Lock()
 _last_request_time = 0.0
 
 
@@ -52,7 +52,7 @@ async def geocode(lon: float, lat: float, cache: CacheStore) -> Location:
         return Location(**cached)
 
     global _last_request_time
-    async with _semaphore:
+    async with _lock:
         # 1 req/sec 속도 제한
         now = asyncio.get_running_loop().time()
         wait = max(0, 1.0 - (now - _last_request_time))

--- a/app/services/composer.py
+++ b/app/services/composer.py
@@ -26,13 +26,13 @@ _breakers = {
 }
 
 
-def get_breaker_statuses() -> list[dict]:
-    return [cb.get_status() for cb in _breakers.values()]
+async def get_breaker_statuses() -> list[dict]:
+    return [await cb.get_status() for cb in _breakers.values()]
 
 
 async def _safe_call(name: str, coro: Awaitable, warnings: list[Warning]):
     cb = _breakers[name]
-    if cb.is_open:
+    if await cb.is_open():
         warnings.append(Warning(module=name, error="Circuit breaker open"))
         return None
     t0 = time.monotonic()

--- a/app/utils/circuit_breaker.py
+++ b/app/utils/circuit_breaker.py
@@ -19,19 +19,19 @@ class CircuitBreaker:
         self._open_until = 0.0
         self._lock = asyncio.Lock()
 
-    @property
-    def is_open(self) -> bool:
-        if self._open_until and time.time() < self._open_until:
-            return True
-        if self._open_until and time.time() >= self._open_until:
-            # half-open: reset and allow retry
-            self._open_until = 0.0
-            self._failure_count = 0
-            circuit_breaker_state.labels(name=self.name).set(2)
-        return False
+    async def is_open(self) -> bool:
+        async with self._lock:
+            if self._open_until and time.time() < self._open_until:
+                return True
+            if self._open_until and time.time() >= self._open_until:
+                # half-open: reset and allow retry
+                self._open_until = 0.0
+                self._failure_count = 0
+                circuit_breaker_state.labels(name=self.name).set(2)
+            return False
 
-    def get_status(self) -> dict:
-        is_open = self.is_open
+    async def get_status(self) -> dict:
+        is_open = await self.is_open()
         cooldown_remaining = max(0.0, self._open_until - time.time()) if is_open else 0.0
         return {
             "name": self.name,

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -13,18 +13,18 @@ class TestCircuitBreakerClosed:
 
     async def test_initial_state_is_closed(self):
         cb = CircuitBreaker("test")
-        assert not cb.is_open
+        assert not await cb.is_open()
 
     async def test_stays_closed_after_success(self):
         cb = CircuitBreaker("test")
         await cb.record_success()
-        assert not cb.is_open
+        assert not await cb.is_open()
 
     async def test_stays_closed_below_threshold(self):
         cb = CircuitBreaker("test", failure_threshold=5)
         for _ in range(4):
             await cb.record_failure()
-        assert not cb.is_open
+        assert not await cb.is_open()
 
     async def test_success_resets_failure_count(self):
         cb = CircuitBreaker("test", failure_threshold=3)
@@ -34,7 +34,7 @@ class TestCircuitBreakerClosed:
         # After reset, 2 more failures should not open
         await cb.record_failure()
         await cb.record_failure()
-        assert not cb.is_open
+        assert not await cb.is_open()
 
 
 class TestCircuitBreakerOpen:
@@ -44,18 +44,18 @@ class TestCircuitBreakerOpen:
         cb = CircuitBreaker("test", failure_threshold=3, cooldown_sec=10.0)
         for _ in range(3):
             await cb.record_failure()
-        assert cb.is_open
+        assert await cb.is_open()
 
     async def test_opens_exactly_at_threshold(self):
         cb = CircuitBreaker("test", failure_threshold=1)
         await cb.record_failure()
-        assert cb.is_open
+        assert await cb.is_open()
 
     async def test_stays_open_during_cooldown(self):
         cb = CircuitBreaker("test", failure_threshold=1, cooldown_sec=100.0)
         await cb.record_failure()
-        assert cb.is_open
-        assert cb.is_open  # Still open on second check
+        assert await cb.is_open()
+        assert await cb.is_open()  # Still open on second check
 
 
 class TestCircuitBreakerHalfOpen:
@@ -65,33 +65,33 @@ class TestCircuitBreakerHalfOpen:
         cb = CircuitBreaker("test", failure_threshold=1, cooldown_sec=0.0)
         await cb.record_failure()
         # cooldown_sec=0 means it expires immediately
-        assert not cb.is_open  # half-open → reset
+        assert not await cb.is_open()  # half-open → reset
 
     async def test_resets_with_short_cooldown(self):
         cb = CircuitBreaker("test", failure_threshold=1, cooldown_sec=0.05)
         await cb.record_failure()
-        assert cb.is_open
+        assert await cb.is_open()
         time.sleep(0.06)
         # After cooldown, should transition to half-open (closed)
-        assert not cb.is_open
+        assert not await cb.is_open()
 
     async def test_reopens_on_failure_after_halfopen(self):
         cb = CircuitBreaker("test", failure_threshold=1, cooldown_sec=0.05)
         await cb.record_failure()
-        assert cb.is_open
+        assert await cb.is_open()
         time.sleep(0.06)
         # After cooldown, half-open reset
-        assert not cb.is_open
+        assert not await cb.is_open()
         # Another failure should re-open
         await cb.record_failure()
-        assert cb.is_open
+        assert await cb.is_open()
 
     async def test_stays_closed_on_success_after_halfopen(self):
         cb = CircuitBreaker("test", failure_threshold=1, cooldown_sec=0.0)
         await cb.record_failure()
-        assert not cb.is_open  # half-open reset
+        assert not await cb.is_open()  # half-open reset
         await cb.record_success()
-        assert not cb.is_open
+        assert not await cb.is_open()
 
 
 class TestCircuitBreakerEdgeCases:
@@ -101,14 +101,14 @@ class TestCircuitBreakerEdgeCases:
         cb = CircuitBreaker("test")
         for _ in range(100):
             await cb.record_success()
-        assert not cb.is_open
+        assert not await cb.is_open()
 
     async def test_custom_parameters(self):
         cb = CircuitBreaker("custom", failure_threshold=2, cooldown_sec=60.0)
         await cb.record_failure()
-        assert not cb.is_open
+        assert not await cb.is_open()
         await cb.record_failure()
-        assert cb.is_open
+        assert await cb.is_open()
 
     async def test_name_preserved(self):
         cb = CircuitBreaker("my-service")
@@ -166,7 +166,7 @@ class TestSafeCall:
         for _ in range(5):
             await _safe_call("landcover", self._async_raise(RuntimeError("fail")), warnings)
 
-        assert _breakers["landcover"].is_open
+        assert await _breakers["landcover"].is_open()
 
     async def test_safe_call_records_success(self):
         from app.services.composer import _breakers, _safe_call

--- a/tests/test_circuit_breaker_lock.py
+++ b/tests/test_circuit_breaker_lock.py
@@ -20,7 +20,7 @@ class TestCircuitBreakerConcurrency:
             await cb.record_failure()
         await asyncio.gather(*[cb.record_success() for _ in range(10)])
         assert cb._failure_count == 0
-        assert not cb.is_open
+        assert not await cb.is_open()
 
     async def test_concurrent_mixed_operations(self):
         """Mixed concurrent success/failure should not corrupt state."""

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -9,7 +9,7 @@ from app.utils.circuit_breaker import CircuitBreaker
 class TestCircuitBreakerGetStatus:
     async def test_closed_status(self):
         cb = CircuitBreaker("geocoder")
-        status = cb.get_status()
+        status = await cb.get_status()
         assert status["name"] == "geocoder"
         assert status["state"] == "closed"
         assert status["failure_count"] == 0
@@ -19,7 +19,7 @@ class TestCircuitBreakerGetStatus:
         cb = CircuitBreaker("geocoder", failure_threshold=2, cooldown_sec=30.0)
         await cb.record_failure()
         await cb.record_failure()
-        status = cb.get_status()
+        status = await cb.get_status()
         assert status["state"] == "open"
         assert status["failure_count"] == 2
         assert status["cooldown_remaining"] > 0
@@ -29,7 +29,7 @@ class TestCircuitBreakerGetStatus:
         await cb.record_failure()
         with patch("app.utils.circuit_breaker.time") as mock_time:
             mock_time.time.return_value = time.time() + 5
-            status = cb.get_status()
+            status = await cb.get_status()
             assert status["cooldown_remaining"] <= 5.1
 
 

--- a/tests/test_geocoder_lock.py
+++ b/tests/test_geocoder_lock.py
@@ -1,0 +1,41 @@
+"""Tests for geocoder rate-limiting Lock (#262)."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.modules.geocoder import _lock
+
+
+class TestGeocoderLock:
+    def test_lock_is_asyncio_lock(self):
+        assert isinstance(_lock, asyncio.Lock)
+
+    async def test_concurrent_requests_serialized(self):
+        """Concurrent geocode calls should be serialized by the Lock."""
+        call_times = []
+
+        def make_resp():
+            resp = MagicMock()
+            resp.json.return_value = {"address": {"country": "Korea"}, "display_name": "Seoul"}
+            resp.raise_for_status.return_value = None
+            return resp
+
+        async def mock_fetch(*args, **kwargs):
+            call_times.append(asyncio.get_running_loop().time())
+            return make_resp()
+
+        with patch("app.modules.geocoder._fetch_nominatim", side_effect=mock_fetch):
+            from app.cache.store import CacheStore
+
+            cache = AsyncMock(spec=CacheStore)
+            cache.get = AsyncMock(return_value=None)
+            cache.set = AsyncMock()
+
+            from app.modules.geocoder import geocode
+
+            await asyncio.gather(
+                geocode(126.0, 37.0, cache),
+                geocode(127.0, 38.0, cache),
+            )
+            # Both calls should have completed (serialized by lock)
+            assert len(call_times) == 2

--- a/tests/test_supabase_lock.py
+++ b/tests/test_supabase_lock.py
@@ -1,0 +1,56 @@
+"""Tests for Supabase get_client() double-check locking (#264)."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+class TestSupabaseDoubleCheckLocking:
+    @pytest.fixture(autouse=True)
+    def reset_client(self):
+        import app.db.supabase as mod
+
+        mod._client = None
+        mod._consecutive_failures = 0
+        mod._last_failure_time = 0.0
+        mod._lock = None
+        yield
+        mod._client = None
+        mod._consecutive_failures = 0
+        mod._last_failure_time = 0.0
+        mod._lock = None
+
+    async def test_concurrent_get_client_creates_once(self):
+        """Multiple concurrent get_client() calls should only create one client."""
+        create_count = 0
+        mock_client = AsyncMock()
+
+        async def mock_acreate(*args, **kwargs):
+            nonlocal create_count
+            create_count += 1
+            await asyncio.sleep(0.01)  # simulate slow init
+            return mock_client
+
+        with (
+            patch("app.db.supabase.acreate_client", side_effect=mock_acreate),
+            patch("app.db.supabase.settings") as mock_settings,
+        ):
+            mock_settings.supabase_url = "http://test"
+            mock_settings.supabase_service_key = "key"
+            mock_settings.supabase_reconnect_backoff_base = 1.0
+            mock_settings.supabase_reconnect_backoff_max = 30.0
+
+            from app.db.supabase import get_client
+
+            results = await asyncio.gather(*[get_client() for _ in range(5)])
+            assert create_count == 1
+            assert all(r is mock_client for r in results)
+
+    async def test_get_lock_returns_same_instance(self):
+        from app.db.supabase import _get_lock
+
+        lock1 = _get_lock()
+        lock2 = _get_lock()
+        assert lock1 is lock2
+        assert isinstance(lock1, asyncio.Lock)


### PR DESCRIPTION
## Summary
- **#262**: geocoder `_last_request_time`을 `asyncio.Lock`으로 보호하여 Nominatim 1 req/sec 정책 준수 (Semaphore→Lock 교체)
- **#263**: `CircuitBreaker.is_open`을 async 메서드로 전환하여 half-open 상태 변경 시 Lock 적용
- **#264**: Supabase `get_client()`에 double-check locking 도입하여 중복 클라이언트 생성 방지

closes #262, closes #263, closes #264

## Test plan
- [x] 기존 circuit breaker 테스트 33개 통과 (is_open → await cb.is_open() 전환)
- [x] geocoder Lock 테스트 2개 추가 (Lock 타입 검증, 동시 요청 직렬화)
- [x] supabase Lock 테스트 2개 추가 (동시 get_client 단일 생성, _get_lock 싱글턴)
- [x] 전체 563 tests passed, lint/format 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)