### PR TITLE
fix(circuit_breaker,context,landcover): monotonic 클럭, 중복 API 방지, 캐시 타임아웃

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -51,6 +51,7 @@ class Settings(BaseSettings):
     health_timeout: float = 3.0
     cache_cleanup_poll_interval: float = 0.5
     overpass_timeout: int = 10
+    cache_write_timeout: float = 5.0
 
     @field_validator(
         "cache_ttl_seconds",
@@ -77,6 +78,7 @@ class Settings(BaseSettings):
         "health_timeout",
         "cache_cleanup_poll_interval",
         "overpass_timeout",
+        "cache_write_timeout",
     )
     @classmethod
     def _positive_int(cls, v: int | float, info) -> int | float:
@@ -162,6 +164,7 @@ class Settings(BaseSettings):
             health_timeout=self.health_timeout,
             cache_cleanup_poll_interval=self.cache_cleanup_poll_interval,
             overpass_timeout=self.overpass_timeout,
+            cache_write_timeout=self.cache_write_timeout,
         )
 
     model_config = {"env_file": ".env"}

--- a/app/modules/context.py
+++ b/app/modules/context.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 
 import httpx
@@ -10,6 +11,9 @@ from app.http_client import get_client
 from app.utils.retry import retry_http
 
 logger = structlog.get_logger()
+
+_context_locks: dict[str, asyncio.Lock] = {}
+_locks_lock = asyncio.Lock()
 
 
 @retry_http
@@ -42,37 +46,49 @@ async def research_context(
         logger.debug("context cache hit", place=place_name, month=month)
         return Context(**cached)
 
-    # DuckDuckGo Instant Answer API (MVP)
-    query = f"{search_name} {month}"
-    events: list[Event] = []
+    async with _locks_lock:
+        if cache_key not in _context_locks:
+            _context_locks[cache_key] = asyncio.Lock()
+        lock = _context_locks[cache_key]
 
-    try:
-        resp = await _fetch_duckduckgo(query)
-        data = resp.json()
+    async with lock:
+        # double-check: 다른 코루틴이 이미 캐시에 저장했을 수 있음
+        cached = await cache.get(cache_key)
+        if cached:
+            logger.debug("context cache hit after lock", place=place_name, month=month)
+            return Context(**cached)
 
-        # Instant Answer에서 관련 토픽 추출
-        for topic in data.get("RelatedTopics", [])[:5]:
-            text = topic.get("Text", "")
-            url = topic.get("FirstURL", "")
-            if text and url:
-                events.append(
-                    Event(
-                        title=text[:200],
-                        date=month,
-                        source_url=url,
-                        relevance="low",
+        # DuckDuckGo Instant Answer API (MVP)
+        query = f"{search_name} {month}"
+        events: list[Event] = []
+
+        try:
+            resp = await _fetch_duckduckgo(query)
+            data = resp.json()
+
+            # Instant Answer에서 관련 토픽 추출
+            for topic in data.get("RelatedTopics", [])[:5]:
+                text = topic.get("Text", "")
+                url = topic.get("FirstURL", "")
+                if text and url:
+                    events.append(
+                        Event(
+                            title=text[:200],
+                            date=month,
+                            source_url=url,
+                            relevance="low",
+                        )
                     )
-                )
-    except (json.JSONDecodeError, httpx.HTTPError, TimeoutError) as e:
-        logger.warning("context research failed", error=str(e))
+        except (json.JSONDecodeError, httpx.HTTPError, TimeoutError) as e:
+            logger.warning("context research failed", error=str(e))
 
-    summary = (
-        f"{search_name} {month} 관련 정보 {len(events)}건 발견."
-        if events
-        else f"{search_name} {month}에 대한 관련 정보를 찾지 못했습니다."
-    )
+        summary = (
+            f"{search_name} {month} 관련 정보 {len(events)}건 발견."
+            if events
+            else f"{search_name} {month}에 대한 관련 정보를 찾지 못했습니다."
+        )
 
-    result = Context(events=events, summary=summary)
-    await cache.set(cache_key, result.model_dump(), ttl_days=7)
-    logger.info("context result", events_count=len(events))
-    return result
+        result = Context(events=events, summary=summary)
+        await cache.set(cache_key, result.model_dump(), ttl_days=7)
+        logger.info("context result", events_count=len(events))
+        return result

--- a/app/modules/landcover.py
+++ b/app/modules/landcover.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 
 import httpx
@@ -115,6 +116,12 @@ out tags;
     summary = ", ".join(summary_parts) if summary_parts else "정보 없음"
 
     result = LandCover(classes=classes, summary=summary)
-    await cache.set(cache_key, result.model_dump(), ttl_seconds=settings.cache_ttl_seconds)
+    try:
+        await asyncio.wait_for(
+            cache.set(cache_key, result.model_dump(), ttl_seconds=settings.cache_ttl_seconds),
+            timeout=settings.cache_write_timeout,
+        )
+    except TimeoutError:
+        logger.warning("landcover cache write timeout", cache_key=cache_key)
     logger.info("landcover result", classes_count=len(classes), summary=summary)
     return result

--- a/app/utils/circuit_breaker.py
+++ b/app/utils/circuit_breaker.py
@@ -21,9 +21,9 @@ class CircuitBreaker:
 
     async def is_open(self) -> bool:
         async with self._lock:
-            if self._open_until and time.time() < self._open_until:
+            if self._open_until and time.monotonic() < self._open_until:
                 return True
-            if self._open_until and time.time() >= self._open_until:
+            if self._open_until and time.monotonic() >= self._open_until:
                 # half-open: reset and allow retry
                 self._open_until = 0.0
                 self._failure_count = 0
@@ -32,7 +32,7 @@ class CircuitBreaker:
 
     async def get_status(self) -> dict:
         is_open = await self.is_open()
-        cooldown_remaining = max(0.0, self._open_until - time.time()) if is_open else 0.0
+        cooldown_remaining = max(0.0, self._open_until - time.monotonic()) if is_open else 0.0
         return {
             "name": self.name,
             "state": "open" if is_open else "closed",
@@ -44,7 +44,7 @@ class CircuitBreaker:
         async with self._lock:
             self._failure_count += 1
             if self._failure_count >= self.failure_threshold:
-                self._open_until = time.time() + self.cooldown_sec
+                self._open_until = time.monotonic() + self.cooldown_sec
                 circuit_breaker_state.labels(name=self.name).set(1)
                 logger.warning(
                     "circuit breaker opened",

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -151,7 +151,7 @@ class TestSafeCall:
 
         # Force circuit open
         _breakers["describer"]._failure_count = 5
-        _breakers["describer"]._open_until = time.time() + 100
+        _breakers["describer"]._open_until = time.monotonic() + 100
 
         warnings: list[Warning] = []
         result = await _safe_call("describer", self._async_value("should not run"), warnings)

--- a/tests/test_circuit_breaker_monotonic.py
+++ b/tests/test_circuit_breaker_monotonic.py
@@ -1,0 +1,38 @@
+"""Tests for CircuitBreaker time.monotonic() usage (#267)."""
+
+import time
+from unittest.mock import patch
+
+from app.utils.circuit_breaker import CircuitBreaker
+
+
+class TestCircuitBreakerMonotonic:
+    async def test_uses_monotonic_not_wall_clock(self):
+        """time.monotonic()를 사용하므로 time.time() 역행에 영향받지 않아야 한다."""
+        cb = CircuitBreaker("test", failure_threshold=1, cooldown_sec=10.0)
+        await cb.record_failure()
+        assert await cb.is_open()
+
+        # time.monotonic()를 충분히 앞으로 이동시키면 쿨다운 만료
+        future = time.monotonic() + 11.0
+        with patch("time.monotonic", return_value=future):
+            assert not await cb.is_open()
+
+    async def test_cooldown_not_affected_by_wall_clock_rollback(self):
+        """벽시계(time.time())가 역행해도 monotonic 기반이므로 정상 동작."""
+        cb = CircuitBreaker("test", failure_threshold=1, cooldown_sec=5.0)
+        await cb.record_failure()
+        assert await cb.is_open()
+
+        # time.time()을 역행시켜도 monotonic 기반이므로 영향 없음
+        # (time.time을 패치해도 코드가 time.monotonic을 쓰므로 상태 불변)
+        with patch("time.time", return_value=0):
+            assert await cb.is_open()
+
+    async def test_get_status_uses_monotonic(self):
+        """get_status()의 cooldown_remaining도 monotonic 기반이어야 한다."""
+        cb = CircuitBreaker("test", failure_threshold=1, cooldown_sec=10.0)
+        await cb.record_failure()
+        status = await cb.get_status()
+        assert status["state"] == "open"
+        assert status["cooldown_remaining"] > 0

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -28,7 +28,7 @@ class TestCircuitBreakerGetStatus:
         cb = CircuitBreaker("geocoder", failure_threshold=1, cooldown_sec=10.0)
         await cb.record_failure()
         with patch("app.utils.circuit_breaker.time") as mock_time:
-            mock_time.time.return_value = time.time() + 5
+            mock_time.monotonic.return_value = time.monotonic() + 5
             status = await cb.get_status()
             assert status["cooldown_remaining"] <= 5.1
 

--- a/tests/test_context_lock.py
+++ b/tests/test_context_lock.py
@@ -1,0 +1,60 @@
+"""Tests for context module asyncio.Lock deduplication (#268)."""
+
+import asyncio
+
+import pytest
+
+from app.cache.store import CacheStore
+from app.modules.context import _context_locks, research_context
+
+
+@pytest.fixture
+async def cache(tmp_path):
+    store = CacheStore(str(tmp_path / "test.db"))
+    await store.init()
+    yield store
+    await store.close()
+
+
+@pytest.fixture(autouse=True)
+def _clear_locks():
+    _context_locks.clear()
+    yield
+    _context_locks.clear()
+
+
+async def test_concurrent_same_key_single_api_call(cache, httpx_mock):
+    """동일 캐시 키로 동시 요청 시 외부 API가 1회만 호출되어야 한다."""
+    httpx_mock.add_response(
+        json={
+            "RelatedTopics": [
+                {"Text": "News item", "FirstURL": "https://example.com/1"},
+            ]
+        }
+    )
+
+    results = await asyncio.gather(
+        research_context("서울", "2025-06-15", cache),
+        research_context("서울", "2025-06-15", cache),
+        research_context("서울", "2025-06-15", cache),
+    )
+
+    # 모든 결과가 동일해야 함
+    for r in results:
+        assert len(r.events) == 1
+
+    # API는 1회만 호출 (나머지는 캐시 hit 또는 lock 대기 후 캐시 hit)
+    assert len(httpx_mock.get_requests()) == 1
+
+
+async def test_different_keys_independent(cache, httpx_mock):
+    """다른 캐시 키는 독립적으로 API를 호출해야 한다."""
+    httpx_mock.add_response(json={"RelatedTopics": []})
+    httpx_mock.add_response(json={"RelatedTopics": []})
+
+    await asyncio.gather(
+        research_context("서울", "2025-06-15", cache),
+        research_context("부산", "2025-07-15", cache),
+    )
+
+    assert len(httpx_mock.get_requests()) == 2

--- a/tests/test_landcover_cache_timeout.py
+++ b/tests/test_landcover_cache_timeout.py
@@ -1,0 +1,59 @@
+"""Tests for landcover cache write timeout (#269)."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.cache.store import CacheStore
+from app.modules.landcover import get_land_cover
+
+
+@pytest.fixture
+async def cache(tmp_path):
+    store = CacheStore(str(tmp_path / "test.db"))
+    await store.init()
+    yield store
+    await store.close()
+
+
+async def test_cache_write_timeout_does_not_hang(cache, httpx_mock):
+    """cache.set()이 타임아웃되면 결과는 정상 반환하고 hang하지 않아야 한다."""
+    httpx_mock.add_response(json={"elements": [{"tags": {"landuse": "residential"}}]})
+
+    async def _slow_set(*args, **kwargs):
+        await asyncio.sleep(100)
+
+    with patch.object(cache, "set", side_effect=_slow_set):
+        with patch("app.modules.landcover.settings") as mock_settings:
+            mock_settings.overpass_url = "https://overpass-api.de/api/interpreter"
+            mock_settings.timeout_landcover = 15.0
+            mock_settings.overpass_timeout = 10
+            mock_settings.cache_ttl_seconds = 86400 * 30
+            mock_settings.cache_write_timeout = 0.01
+
+            result = await get_land_cover(126.978, 37.566, cache)
+
+    assert len(result.classes) == 1
+    assert result.classes[0].type == "residential"
+
+
+async def test_cache_write_success(cache, httpx_mock):
+    """정상적인 cache.set()은 타임아웃 없이 완료되어야 한다."""
+    httpx_mock.add_response(json={"elements": [{"tags": {"landuse": "forest"}}]})
+
+    mock_set = AsyncMock()
+    with patch.object(cache, "set", mock_set):
+        result = await get_land_cover(10.0, 20.0, cache)
+
+    mock_set.assert_called_once()
+    assert result.classes[0].type == "forest"
+
+
+async def test_cache_write_timeout_config_default():
+    """cache_write_timeout 기본값이 설정되어 있어야 한다."""
+    from app.config import Settings
+
+    fields = Settings.model_fields
+    assert "cache_write_timeout" in fields
+    assert fields["cache_write_timeout"].default == 5.0


### PR DESCRIPTION
## Summary
- `circuit_breaker`: `time.time()` → `time.monotonic()` 전환으로 NTP 클럭 역행 시 쿨다운 오동작 방지 (closes #267)
- `context`: `asyncio.Lock` 적용으로 동일 캐시 키 동시 요청 시 중복 DuckDuckGo API 호출 방지 (closes #268)
- `landcover`: `cache.set()`을 `asyncio.wait_for()`로 감싸고 `cache_write_timeout` 상수 외부화 (closes #269)

## Test plan
- [x] circuit_breaker monotonic 전환 테스트 3건 추가
- [x] context Lock 동시 요청 중복 방지 테스트 2건 추가
- [x] landcover 캐시 쓰기 타임아웃 테스트 3건 추가
- [x] 기존 테스트 time.time → time.monotonic 패치 수정
- [x] 전체 571 tests passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)